### PR TITLE
WIP Replace login prompt with modal dialog

### DIFF
--- a/docs/elements/apps/pos-app-browser/readme.md
+++ b/docs/elements/apps/pos-app-browser/readme.md
@@ -37,6 +37,8 @@ graph TD;
   pos-login --> pos-picture
   pos-login --> pos-label
   pos-login --> ion-button
+  pos-login --> pos-dialog
+  pos-login --> pos-login-form
   pos-resource --> ion-progress-bar
   pos-resource --> ion-card
   pos-resource --> ion-card-header
@@ -46,6 +48,7 @@ graph TD;
   pos-image --> ion-skeleton-text
   pos-image --> ion-icon
   ion-button --> ion-ripple-effect
+  pos-dialog --> ion-icon
   pos-router --> pos-add-new-thing
   pos-router --> pos-navigation-bar
   pos-router --> pos-resource
@@ -53,7 +56,6 @@ graph TD;
   pos-add-new-thing --> ion-icon
   pos-add-new-thing --> pos-dialog
   pos-add-new-thing --> pos-new-thing-form
-  pos-dialog --> ion-icon
   pos-new-thing-form --> pos-select-term
   pos-navigation-bar --> ion-searchbar
   ion-searchbar --> ion-icon

--- a/docs/elements/apps/pos-app-browser/readme.md
+++ b/docs/elements/apps/pos-app-browser/readme.md
@@ -51,7 +51,9 @@ graph TD;
   pos-router --> pos-resource
   pos-router --> pos-type-router
   pos-add-new-thing --> ion-icon
+  pos-add-new-thing --> pos-dialog
   pos-add-new-thing --> pos-new-thing-form
+  pos-dialog --> ion-icon
   pos-new-thing-form --> pos-select-term
   pos-navigation-bar --> ion-searchbar
   ion-searchbar --> ion-icon

--- a/docs/elements/components/pos-add-new-thing/readme.md
+++ b/docs/elements/components/pos-add-new-thing/readme.md
@@ -21,13 +21,16 @@
 ### Depends on
 
 - ion-icon
+- [pos-dialog](../pos-dialog)
 - [pos-new-thing-form](../pos-new-thing-form)
 
 ### Graph
 ```mermaid
 graph TD;
   pos-add-new-thing --> ion-icon
+  pos-add-new-thing --> pos-dialog
   pos-add-new-thing --> pos-new-thing-form
+  pos-dialog --> ion-icon
   pos-new-thing-form --> pos-select-term
   pos-router --> pos-add-new-thing
   style pos-add-new-thing fill:#f9f,stroke:#333,stroke-width:4px

--- a/docs/elements/components/pos-dialog/readme.md
+++ b/docs/elements/components/pos-dialog/readme.md
@@ -1,0 +1,55 @@
+# pos-dialog
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Overview
+
+Styled wrapper around native dialog element, with slots `dialog-title` and `dialog-content`
+
+## Methods
+
+### `close() => Promise<void>`
+
+
+
+#### Returns
+
+Type: `Promise<void>`
+
+
+
+### `showModal() => Promise<void>`
+
+
+
+#### Returns
+
+Type: `Promise<void>`
+
+
+
+
+## Dependencies
+
+### Used by
+
+ - [pos-add-new-thing](../pos-add-new-thing)
+
+### Depends on
+
+- ion-icon
+
+### Graph
+```mermaid
+graph TD;
+  pos-dialog --> ion-icon
+  pos-add-new-thing --> pos-dialog
+  style pos-dialog fill:#f9f,stroke:#333,stroke-width:4px
+```
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/docs/elements/components/pos-dialog/readme.md
+++ b/docs/elements/components/pos-dialog/readme.md
@@ -7,7 +7,7 @@
 
 ## Overview
 
-Styled wrapper around native dialog element, with slots `dialog-title` and `dialog-content`
+Styled wrapper around native dialog element, with slots `title` and `content`
 
 ## Methods
 

--- a/docs/elements/components/pos-dialog/readme.md
+++ b/docs/elements/components/pos-dialog/readme.md
@@ -37,6 +37,7 @@ Type: `Promise<void>`
 ### Used by
 
  - [pos-add-new-thing](../pos-add-new-thing)
+ - [pos-login](../pos-login)
 
 ### Depends on
 
@@ -47,6 +48,7 @@ Type: `Promise<void>`
 graph TD;
   pos-dialog --> ion-icon
   pos-add-new-thing --> pos-dialog
+  pos-login --> pos-dialog
   style pos-dialog fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/docs/elements/components/pos-login-form/readme.md
+++ b/docs/elements/components/pos-login-form/readme.md
@@ -1,0 +1,31 @@
+# pos-login-form
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Events
+
+| Event            | Description                                 | Type               |
+| ---------------- | ------------------------------------------- | ------------------ |
+| `idpUrlSelected` | Emits the selected IDP URL to use for login | `CustomEvent<any>` |
+| `pod-os:error`   |                                             | `CustomEvent<any>` |
+
+
+## Dependencies
+
+### Used by
+
+ - [pos-login](../pos-login)
+
+### Graph
+```mermaid
+graph TD;
+  pos-login --> pos-login-form
+  style pos-login-form fill:#f9f,stroke:#333,stroke-width:4px
+```
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/docs/elements/components/pos-login-form/readme.md
+++ b/docs/elements/components/pos-login-form/readme.md
@@ -7,10 +7,9 @@
 
 ## Events
 
-| Event            | Description                                 | Type               |
-| ---------------- | ------------------------------------------- | ------------------ |
-| `idpUrlSelected` | Emits the selected IDP URL to use for login | `CustomEvent<any>` |
-| `pod-os:error`   |                                             | `CustomEvent<any>` |
+| Event                     | Description                                 | Type               |
+| ------------------------- | ------------------------------------------- | ------------------ |
+| `pod-os:idp-url-selected` | Emits the selected IDP URL to use for login | `CustomEvent<any>` |
 
 
 ## Dependencies

--- a/docs/elements/components/pos-login/readme.md
+++ b/docs/elements/components/pos-login/readme.md
@@ -24,6 +24,8 @@
 - [pos-picture](../pos-picture)
 - [pos-label](../pos-label)
 - ion-button
+- [pos-dialog](../pos-dialog)
+- [pos-login-form](../pos-login-form)
 
 ### Graph
 ```mermaid
@@ -32,6 +34,8 @@ graph TD;
   pos-login --> pos-picture
   pos-login --> pos-label
   pos-login --> ion-button
+  pos-login --> pos-dialog
+  pos-login --> pos-login-form
   pos-resource --> ion-progress-bar
   pos-resource --> ion-card
   pos-resource --> ion-card-header
@@ -41,6 +45,7 @@ graph TD;
   pos-image --> ion-skeleton-text
   pos-image --> ion-icon
   ion-button --> ion-ripple-effect
+  pos-dialog --> ion-icon
   pos-app-browser --> pos-login
   style pos-login fill:#f9f,stroke:#333,stroke-width:4px
 ```

--- a/docs/elements/components/pos-router/readme.md
+++ b/docs/elements/components/pos-router/readme.md
@@ -26,7 +26,9 @@ graph TD;
   pos-router --> pos-resource
   pos-router --> pos-type-router
   pos-add-new-thing --> ion-icon
+  pos-add-new-thing --> pos-dialog
   pos-add-new-thing --> pos-new-thing-form
+  pos-dialog --> ion-icon
   pos-new-thing-form --> pos-select-term
   pos-navigation-bar --> ion-searchbar
   ion-searchbar --> ion-icon

--- a/elements/CHANGELOG.md
+++ b/elements/CHANGELOG.md
@@ -6,9 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Added
+
+- [pos-dialog]: A dialog component with a common style
+
 ### Changed
 
 - [pos-app](../docs/elements/components/pos-app): After login `pos-app` now loads the preferences file that is linked in the user's WebID profile (if any).
+- [pos-add-new-thing]: Refactored to use [pos-dialog]
+
+[pos-add-new-thing]: ../docs/elements/components/pos-add-new-thing
+[pos-dialog]: ../docs/elements/components/pos-dialog
 
 ## 0.13.0
 

--- a/elements/CHANGELOG.md
+++ b/elements/CHANGELOG.md
@@ -9,10 +9,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 
 - [pos-dialog](../docs/elements/components/pos-dialog): A dialog component with a common style
+- [pos-login-form](../docs/elements/components/pos-login-form): A form to enter IDP URL, supporting built-in browser autocomplete
 
 ### Changed
 
 - [pos-app](../docs/elements/components/pos-app): After login `pos-app` now loads the preferences file that is linked in the user's WebID profile (if any).
+- [pos-login](../docs/elements/components/pos-login): Uses [pos-dialog] instead of a `prompt`
 
 ## 0.13.0
 

--- a/elements/CHANGELOG.md
+++ b/elements/CHANGELOG.md
@@ -8,15 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
-- [pos-dialog]: A dialog component with a common style
+- [pos-dialog](../docs/elements/components/pos-dialog): A dialog component with a common style
 
 ### Changed
 
 - [pos-app](../docs/elements/components/pos-app): After login `pos-app` now loads the preferences file that is linked in the user's WebID profile (if any).
-- [pos-add-new-thing]: Refactored to use [pos-dialog]
-
-[pos-add-new-thing]: ../docs/elements/components/pos-add-new-thing
-[pos-dialog]: ../docs/elements/components/pos-dialog
 
 ## 0.13.0
 

--- a/elements/src/components.d.ts
+++ b/elements/src/components.d.ts
@@ -515,6 +515,9 @@ declare namespace LocalJSX {
         "onPod-os:init"?: (event: PosLoginCustomEvent<any>) => void;
     }
     interface PosLoginForm {
+        /**
+          * Emits the selected IDP URL to use for login
+         */
         "onIdpUrlSelected"?: (event: PosLoginFormCustomEvent<any>) => void;
         "onPod-os:error"?: (event: PosLoginFormCustomEvent<any>) => void;
     }

--- a/elements/src/components.d.ts
+++ b/elements/src/components.d.ts
@@ -31,6 +31,9 @@ export namespace Components {
     }
     interface PosDescription {
     }
+    /**
+     * Styled wrapper around native dialog element, with slots `dialog-title` and `dialog-content`
+     */
     interface PosDialog {
         "close": () => Promise<void>;
         "showModal": () => Promise<void>;
@@ -255,6 +258,9 @@ declare global {
         prototype: HTMLPosDescriptionElement;
         new (): HTMLPosDescriptionElement;
     };
+    /**
+     * Styled wrapper around native dialog element, with slots `dialog-title` and `dialog-content`
+     */
     interface HTMLPosDialogElement extends Components.PosDialog, HTMLStencilElement {
     }
     var HTMLPosDialogElement: {
@@ -452,6 +458,9 @@ declare namespace LocalJSX {
     interface PosDescription {
         "onPod-os:resource"?: (event: PosDescriptionCustomEvent<any>) => void;
     }
+    /**
+     * Styled wrapper around native dialog element, with slots `dialog-title` and `dialog-content`
+     */
     interface PosDialog {
     }
     interface PosDocument {
@@ -593,6 +602,9 @@ declare module "@stencil/core" {
             "pos-container-contents": LocalJSX.PosContainerContents & JSXBase.HTMLAttributes<HTMLPosContainerContentsElement>;
             "pos-container-item": LocalJSX.PosContainerItem & JSXBase.HTMLAttributes<HTMLPosContainerItemElement>;
             "pos-description": LocalJSX.PosDescription & JSXBase.HTMLAttributes<HTMLPosDescriptionElement>;
+            /**
+             * Styled wrapper around native dialog element, with slots `dialog-title` and `dialog-content`
+             */
             "pos-dialog": LocalJSX.PosDialog & JSXBase.HTMLAttributes<HTMLPosDialogElement>;
             "pos-document": LocalJSX.PosDocument & JSXBase.HTMLAttributes<HTMLPosDocumentElement>;
             "pos-error-toast": LocalJSX.PosErrorToast & JSXBase.HTMLAttributes<HTMLPosErrorToastElement>;

--- a/elements/src/components.d.ts
+++ b/elements/src/components.d.ts
@@ -31,6 +31,10 @@ export namespace Components {
     }
     interface PosDescription {
     }
+    interface PosDialog {
+        "close": () => Promise<void>;
+        "showModal": () => Promise<void>;
+    }
     interface PosDocument {
         "alt": string;
         "src": string;
@@ -251,6 +255,12 @@ declare global {
         prototype: HTMLPosDescriptionElement;
         new (): HTMLPosDescriptionElement;
     };
+    interface HTMLPosDialogElement extends Components.PosDialog, HTMLStencilElement {
+    }
+    var HTMLPosDialogElement: {
+        prototype: HTMLPosDialogElement;
+        new (): HTMLPosDialogElement;
+    };
     interface HTMLPosDocumentElement extends Components.PosDocument, HTMLStencilElement {
     }
     var HTMLPosDocumentElement: {
@@ -378,6 +388,7 @@ declare global {
         "pos-container-contents": HTMLPosContainerContentsElement;
         "pos-container-item": HTMLPosContainerItemElement;
         "pos-description": HTMLPosDescriptionElement;
+        "pos-dialog": HTMLPosDialogElement;
         "pos-document": HTMLPosDocumentElement;
         "pos-error-toast": HTMLPosErrorToastElement;
         "pos-image": HTMLPosImageElement;
@@ -440,6 +451,8 @@ declare namespace LocalJSX {
     }
     interface PosDescription {
         "onPod-os:resource"?: (event: PosDescriptionCustomEvent<any>) => void;
+    }
+    interface PosDialog {
     }
     interface PosDocument {
         "alt"?: string;
@@ -542,6 +555,7 @@ declare namespace LocalJSX {
         "pos-container-contents": PosContainerContents;
         "pos-container-item": PosContainerItem;
         "pos-description": PosDescription;
+        "pos-dialog": PosDialog;
         "pos-document": PosDocument;
         "pos-error-toast": PosErrorToast;
         "pos-image": PosImage;
@@ -579,6 +593,7 @@ declare module "@stencil/core" {
             "pos-container-contents": LocalJSX.PosContainerContents & JSXBase.HTMLAttributes<HTMLPosContainerContentsElement>;
             "pos-container-item": LocalJSX.PosContainerItem & JSXBase.HTMLAttributes<HTMLPosContainerItemElement>;
             "pos-description": LocalJSX.PosDescription & JSXBase.HTMLAttributes<HTMLPosDescriptionElement>;
+            "pos-dialog": LocalJSX.PosDialog & JSXBase.HTMLAttributes<HTMLPosDialogElement>;
             "pos-document": LocalJSX.PosDocument & JSXBase.HTMLAttributes<HTMLPosDocumentElement>;
             "pos-error-toast": LocalJSX.PosErrorToast & JSXBase.HTMLAttributes<HTMLPosErrorToastElement>;
             "pos-image": LocalJSX.PosImage & JSXBase.HTMLAttributes<HTMLPosImageElement>;

--- a/elements/src/components.d.ts
+++ b/elements/src/components.d.ts
@@ -518,8 +518,7 @@ declare namespace LocalJSX {
         /**
           * Emits the selected IDP URL to use for login
          */
-        "onIdpUrlSelected"?: (event: PosLoginFormCustomEvent<any>) => void;
-        "onPod-os:error"?: (event: PosLoginFormCustomEvent<any>) => void;
+        "onPod-os:idp-url-selected"?: (event: PosLoginFormCustomEvent<any>) => void;
     }
     interface PosNavigationBar {
         "onPod-os:link"?: (event: PosNavigationBarCustomEvent<any>) => void;

--- a/elements/src/components.d.ts
+++ b/elements/src/components.d.ts
@@ -32,7 +32,7 @@ export namespace Components {
     interface PosDescription {
     }
     /**
-     * Styled wrapper around native dialog element, with slots `dialog-title` and `dialog-content`
+     * Styled wrapper around native dialog element, with slots `title` and `content`
      */
     interface PosDialog {
         "close": () => Promise<void>;
@@ -259,7 +259,7 @@ declare global {
         new (): HTMLPosDescriptionElement;
     };
     /**
-     * Styled wrapper around native dialog element, with slots `dialog-title` and `dialog-content`
+     * Styled wrapper around native dialog element, with slots `title` and `content`
      */
     interface HTMLPosDialogElement extends Components.PosDialog, HTMLStencilElement {
     }
@@ -459,7 +459,7 @@ declare namespace LocalJSX {
         "onPod-os:resource"?: (event: PosDescriptionCustomEvent<any>) => void;
     }
     /**
-     * Styled wrapper around native dialog element, with slots `dialog-title` and `dialog-content`
+     * Styled wrapper around native dialog element, with slots `title` and `content`
      */
     interface PosDialog {
     }
@@ -603,7 +603,7 @@ declare module "@stencil/core" {
             "pos-container-item": LocalJSX.PosContainerItem & JSXBase.HTMLAttributes<HTMLPosContainerItemElement>;
             "pos-description": LocalJSX.PosDescription & JSXBase.HTMLAttributes<HTMLPosDescriptionElement>;
             /**
-             * Styled wrapper around native dialog element, with slots `dialog-title` and `dialog-content`
+             * Styled wrapper around native dialog element, with slots `title` and `content`
              */
             "pos-dialog": LocalJSX.PosDialog & JSXBase.HTMLAttributes<HTMLPosDialogElement>;
             "pos-document": LocalJSX.PosDocument & JSXBase.HTMLAttributes<HTMLPosDocumentElement>;

--- a/elements/src/components.d.ts
+++ b/elements/src/components.d.ts
@@ -54,6 +54,8 @@ export namespace Components {
     }
     interface PosLogin {
     }
+    interface PosLoginForm {
+    }
     interface PosNavigationBar {
         "uri": string;
     }
@@ -91,6 +93,8 @@ export namespace Components {
           * URI of the predicate to get the value from
          */
         "predicate": string;
+    }
+    interface TestComponent {
     }
 }
 export interface PosAddLiteralValueCustomEvent<T> extends CustomEvent<T> {
@@ -136,6 +140,10 @@ export interface PosLiteralsCustomEvent<T> extends CustomEvent<T> {
 export interface PosLoginCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLPosLoginElement;
+}
+export interface PosLoginFormCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLPosLoginFormElement;
 }
 export interface PosNavigationBarCustomEvent<T> extends CustomEvent<T> {
     detail: T;
@@ -303,6 +311,12 @@ declare global {
         prototype: HTMLPosLoginElement;
         new (): HTMLPosLoginElement;
     };
+    interface HTMLPosLoginFormElement extends Components.PosLoginForm, HTMLStencilElement {
+    }
+    var HTMLPosLoginFormElement: {
+        prototype: HTMLPosLoginFormElement;
+        new (): HTMLPosLoginFormElement;
+    };
     interface HTMLPosNavigationBarElement extends Components.PosNavigationBar, HTMLStencilElement {
     }
     var HTMLPosNavigationBarElement: {
@@ -381,6 +395,12 @@ declare global {
         prototype: HTMLPosValueElement;
         new (): HTMLPosValueElement;
     };
+    interface HTMLTestComponentElement extends Components.TestComponent, HTMLStencilElement {
+    }
+    var HTMLTestComponentElement: {
+        prototype: HTMLTestComponentElement;
+        new (): HTMLTestComponentElement;
+    };
     interface HTMLElementTagNameMap {
         "pos-add-literal-value": HTMLPosAddLiteralValueElement;
         "pos-add-new-thing": HTMLPosAddNewThingElement;
@@ -401,6 +421,7 @@ declare global {
         "pos-label": HTMLPosLabelElement;
         "pos-literals": HTMLPosLiteralsElement;
         "pos-login": HTMLPosLoginElement;
+        "pos-login-form": HTMLPosLoginFormElement;
         "pos-navigation-bar": HTMLPosNavigationBarElement;
         "pos-new-thing-form": HTMLPosNewThingFormElement;
         "pos-picture": HTMLPosPictureElement;
@@ -414,6 +435,7 @@ declare global {
         "pos-type-badges": HTMLPosTypeBadgesElement;
         "pos-type-router": HTMLPosTypeRouterElement;
         "pos-value": HTMLPosValueElement;
+        "test-component": HTMLTestComponentElement;
     }
 }
 declare namespace LocalJSX {
@@ -492,6 +514,10 @@ declare namespace LocalJSX {
     interface PosLogin {
         "onPod-os:init"?: (event: PosLoginCustomEvent<any>) => void;
     }
+    interface PosLoginForm {
+        "onIdpUrlSelected"?: (event: PosLoginFormCustomEvent<any>) => void;
+        "onPod-os:error"?: (event: PosLoginFormCustomEvent<any>) => void;
+    }
     interface PosNavigationBar {
         "onPod-os:link"?: (event: PosNavigationBarCustomEvent<any>) => void;
         "uri"?: string;
@@ -551,6 +577,8 @@ declare namespace LocalJSX {
          */
         "predicate"?: string;
     }
+    interface TestComponent {
+    }
     interface IntrinsicElements {
         "pos-add-literal-value": PosAddLiteralValue;
         "pos-add-new-thing": PosAddNewThing;
@@ -571,6 +599,7 @@ declare namespace LocalJSX {
         "pos-label": PosLabel;
         "pos-literals": PosLiterals;
         "pos-login": PosLogin;
+        "pos-login-form": PosLoginForm;
         "pos-navigation-bar": PosNavigationBar;
         "pos-new-thing-form": PosNewThingForm;
         "pos-picture": PosPicture;
@@ -584,6 +613,7 @@ declare namespace LocalJSX {
         "pos-type-badges": PosTypeBadges;
         "pos-type-router": PosTypeRouter;
         "pos-value": PosValue;
+        "test-component": TestComponent;
     }
 }
 export { LocalJSX as JSX };
@@ -612,6 +642,7 @@ declare module "@stencil/core" {
             "pos-label": LocalJSX.PosLabel & JSXBase.HTMLAttributes<HTMLPosLabelElement>;
             "pos-literals": LocalJSX.PosLiterals & JSXBase.HTMLAttributes<HTMLPosLiteralsElement>;
             "pos-login": LocalJSX.PosLogin & JSXBase.HTMLAttributes<HTMLPosLoginElement>;
+            "pos-login-form": LocalJSX.PosLoginForm & JSXBase.HTMLAttributes<HTMLPosLoginFormElement>;
             "pos-navigation-bar": LocalJSX.PosNavigationBar & JSXBase.HTMLAttributes<HTMLPosNavigationBarElement>;
             "pos-new-thing-form": LocalJSX.PosNewThingForm & JSXBase.HTMLAttributes<HTMLPosNewThingFormElement>;
             "pos-picture": LocalJSX.PosPicture & JSXBase.HTMLAttributes<HTMLPosPictureElement>;
@@ -625,6 +656,7 @@ declare module "@stencil/core" {
             "pos-type-badges": LocalJSX.PosTypeBadges & JSXBase.HTMLAttributes<HTMLPosTypeBadgesElement>;
             "pos-type-router": LocalJSX.PosTypeRouter & JSXBase.HTMLAttributes<HTMLPosTypeRouterElement>;
             "pos-value": LocalJSX.PosValue & JSXBase.HTMLAttributes<HTMLPosValueElement>;
+            "test-component": LocalJSX.TestComponent & JSXBase.HTMLAttributes<HTMLTestComponentElement>;
         }
     }
 }

--- a/elements/src/components/pos-add-new-thing/pos-add-new-thing.css
+++ b/elements/src/components/pos-add-new-thing/pos-add-new-thing.css
@@ -23,7 +23,3 @@ button#new:hover, button#new:focus {
   box-shadow: var(--shadow-sm);
 }
 
-pos-new-thing-form {
-  margin: var(--scale-3)
-}
-

--- a/elements/src/components/pos-add-new-thing/pos-add-new-thing.css
+++ b/elements/src/components/pos-add-new-thing/pos-add-new-thing.css
@@ -23,46 +23,6 @@ button#new:hover, button#new:focus {
   box-shadow: var(--shadow-sm);
 }
 
-dialog {
-  background-color: var(--pos-background-color);
-  border: none;
-  border-radius: var(--radius-md);
-  box-shadow: var(--shadow-md);
-  max-width: var(--width-xs);
-}
-
-dialog #title {
-  flex-grow: 1;
-  font-weight: var(--weight-light);
-  font-size: var(--scale-2);
-}
-
-dialog header {
-  display: flex;
-  flex-direction: row;
-  justify-content: start;
-  align-items: center;
-  gap: var(--scale-0);
-  border-bottom-style: inset;
-  padding-bottom: var(--scale-0);
-}
-
-button#close {
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border: none;
-  background: none;
-  font-size: var(--scale-3);
-  color: var(--color-grey-500);
-}
-
-button#close:hover {
-  color: var(--color-grey-800);
-}
-
-
 pos-new-thing-form {
   margin: var(--scale-3)
 }

--- a/elements/src/components/pos-add-new-thing/pos-add-new-thing.tsx
+++ b/elements/src/components/pos-add-new-thing/pos-add-new-thing.tsx
@@ -21,8 +21,8 @@ export class PosAddNewThing {
           <ion-icon name="add-circle-outline"></ion-icon>
         </button>
         <pos-dialog ref={el => (this.dialog = el as HTMLPosDialogElement)}>
-          <span slot="dialog-title">Add a new thing</span>
-          <pos-new-thing-form slot="dialog-content" referenceUri={this.referenceUri} />
+          <span slot="title">Add a new thing</span>
+          <pos-new-thing-form slot="content" referenceUri={this.referenceUri} />
         </pos-dialog>
       </Host>
     );

--- a/elements/src/components/pos-add-new-thing/pos-add-new-thing.tsx
+++ b/elements/src/components/pos-add-new-thing/pos-add-new-thing.tsx
@@ -21,8 +21,8 @@ export class PosAddNewThing {
           <ion-icon name="add-circle-outline"></ion-icon>
         </button>
         <pos-dialog ref={el => (this.dialog = el as HTMLPosDialogElement)}>
-          <span>Add a new thing</span>
-          <pos-new-thing-form referenceUri={this.referenceUri} />
+          <span slot="dialog-title">Add a new thing</span>
+          <pos-new-thing-form slot="dialog-content" referenceUri={this.referenceUri} />
         </pos-dialog>
       </Host>
     );

--- a/elements/src/components/pos-add-new-thing/pos-add-new-thing.tsx
+++ b/elements/src/components/pos-add-new-thing/pos-add-new-thing.tsx
@@ -8,30 +8,22 @@ import { Component, Host, h, Prop } from '@stencil/core';
 export class PosAddNewThing {
   @Prop() referenceUri!: string;
 
-  private dialog: HTMLDialogElement;
+  private dialog: HTMLPosDialogElement;
 
   openDialog() {
     this.dialog.showModal();
   }
 
-  closeDialog() {
-    this.dialog.close();
-  }
   render() {
     return (
       <Host>
         <button id="new" title="Add a new thing" onClick={() => this.openDialog()}>
           <ion-icon name="add-circle-outline"></ion-icon>
         </button>
-        <dialog ref={el => (this.dialog = el as HTMLDialogElement)}>
-          <header>
-            <span id="title">Add a new thing</span>
-            <button tabindex={-1} id="close" title="Close" onClick={() => this.closeDialog()}>
-              <ion-icon name="close-outline"></ion-icon>
-            </button>
-          </header>
+        <pos-dialog ref={el => (this.dialog = el as HTMLPosDialogElement)}>
+          <span>Add a new thing</span>
           <pos-new-thing-form referenceUri={this.referenceUri} />
-        </dialog>
+        </pos-dialog>
       </Host>
     );
   }

--- a/elements/src/components/pos-add-new-thing/test/pos-add-new-thing.spec.tsx
+++ b/elements/src/components/pos-add-new-thing/test/pos-add-new-thing.spec.tsx
@@ -15,10 +15,10 @@ describe('pos-add-new-thing', () => {
             <ion-icon name="add-circle-outline"></ion-icon>
         </button>
         <pos-dialog>
-                <span slot="dialog-title">
+                <span slot="title">
                       Add a new thing
                 </span>
-            <pos-new-thing-form referenceUri="https://pod.test/" slot="dialog-content"/>
+            <pos-new-thing-form referenceUri="https://pod.test/" slot="content"/>
         </pos-dialog>
     </mock:shadow-root>
 </pos-add-new-thing>

--- a/elements/src/components/pos-add-new-thing/test/pos-add-new-thing.spec.tsx
+++ b/elements/src/components/pos-add-new-thing/test/pos-add-new-thing.spec.tsx
@@ -14,17 +14,12 @@ describe('pos-add-new-thing', () => {
         <button id="new" title="Add a new thing">
             <ion-icon name="add-circle-outline"></ion-icon>
         </button>
-        <dialog>
-            <header>
-                <span id="title">
-                  Add a new thing
+        <pos-dialog>
+                <span slot="dialog-title">
+                      Add a new thing
                 </span>
-                <button tabindex="-1" id="close" title="Close">
-                    <ion-icon name="close-outline"></ion-icon>
-                </button>
-            </header>
-            <pos-new-thing-form referenceUri="https://pod.test/" />
-        </dialog>
+            <pos-new-thing-form referenceUri="https://pod.test/" slot="dialog-content"/>
+        </pos-dialog>
     </mock:shadow-root>
 </pos-add-new-thing>
     `);
@@ -37,32 +32,12 @@ describe('pos-add-new-thing', () => {
       supportsShadowDom: false,
     });
 
-    const dialog = page.root.querySelector('dialog');
+    const dialog = page.root.querySelector('pos-dialog');
     dialog.showModal = jest.fn();
 
     const button = screen.getByTitle('Add a new thing');
     button.click();
 
     expect(dialog.showModal).toHaveBeenCalled();
-  });
-
-  it('closes the modal dialog, when the close button is clicked', async () => {
-    const page = await newSpecPage({
-      components: [PosAddNewThing],
-      html: `<pos-add-new-thing reference-uri="https://pod.test/"></pos-add-new-thing>`,
-      supportsShadowDom: false,
-    });
-
-    const dialog = page.root.querySelector('dialog');
-    dialog.showModal = jest.fn();
-    dialog.close = jest.fn();
-
-    const button = screen.getByTitle('Add a new thing');
-    button.click();
-
-    const closeButton = screen.getByTitle('Close');
-    closeButton.click();
-
-    expect(dialog.close).toHaveBeenCalled();
   });
 });

--- a/elements/src/components/pos-dialog/pos-dialog.css
+++ b/elements/src/components/pos-dialog/pos-dialog.css
@@ -27,6 +27,10 @@ dialog header {
   padding-bottom: var(--scale-0);
 }
 
+dialog [name='dialog-content']::slotted(*) {
+  margin: var(--scale-3);
+}
+
 button#close {
   cursor: pointer;
   display: flex;

--- a/elements/src/components/pos-dialog/pos-dialog.css
+++ b/elements/src/components/pos-dialog/pos-dialog.css
@@ -1,0 +1,57 @@
+:host {
+  font-family: var(--font-sans);
+  display: block;
+}
+
+button#new {
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  width: var(--scale-5);
+  height: var(--scale-5);
+  background-color: var(--pos-primary-color);
+  color: var(--color-grey-50);
+  font-size: var(--scale-6);
+  border-radius: var(--radius-xs);
+}
+
+dialog {
+  background-color: var(--pos-background-color);
+  border: none;
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-md);
+  max-width: var(--width-xs);
+}
+
+dialog #title {
+  flex-grow: 1;
+  font-weight: var(--weight-light);
+  font-size: var(--scale-2);
+}
+
+dialog header {
+  display: flex;
+  flex-direction: row;
+  justify-content: start;
+  align-items: center;
+  gap: var(--scale-0);
+  border-bottom-style: inset;
+  padding-bottom: var(--scale-0);
+}
+
+button#close {
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background: none;
+  font-size: var(--scale-3);
+  color: var(--color-grey-500);
+}
+
+button#close:hover {
+  color: var(--color-grey-800);
+}

--- a/elements/src/components/pos-dialog/pos-dialog.css
+++ b/elements/src/components/pos-dialog/pos-dialog.css
@@ -11,7 +11,7 @@ dialog {
   max-width: var(--width-xs);
 }
 
-dialog #title {
+dialog slot[name='title']::slotted(*) {
   flex-grow: 1;
   font-weight: var(--weight-light);
   font-size: var(--scale-2);

--- a/elements/src/components/pos-dialog/pos-dialog.css
+++ b/elements/src/components/pos-dialog/pos-dialog.css
@@ -27,7 +27,7 @@ dialog header {
   padding-bottom: var(--scale-0);
 }
 
-dialog [name='dialog-content']::slotted(*) {
+dialog [name='content']::slotted(*) {
   margin: var(--scale-3);
 }
 

--- a/elements/src/components/pos-dialog/pos-dialog.css
+++ b/elements/src/components/pos-dialog/pos-dialog.css
@@ -3,20 +3,6 @@
   display: block;
 }
 
-button#new {
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border: none;
-  width: var(--scale-5);
-  height: var(--scale-5);
-  background-color: var(--pos-primary-color);
-  color: var(--color-grey-50);
-  font-size: var(--scale-6);
-  border-radius: var(--radius-xs);
-}
-
 dialog {
   background-color: var(--pos-background-color);
   border: none;

--- a/elements/src/components/pos-dialog/pos-dialog.tsx
+++ b/elements/src/components/pos-dialog/pos-dialog.tsx
@@ -1,0 +1,36 @@
+import { Component, Host, h, Prop, Method } from '@stencil/core';
+
+@Component({
+    tag: 'pos-dialog',
+    styleUrl: 'pos-dialog.css',
+    shadow: true,
+})
+export class PosDialog {
+
+    private dialog: HTMLDialogElement;
+
+    @Method()
+    async showModal() {
+        this.dialog.showModal();
+    }
+
+    @Method()
+    async close() {
+        this.dialog.close();
+    }
+
+    render() {
+        return (
+            <Host>
+                <dialog ref={el => (this.dialog = el as HTMLDialogElement)} >
+                    <header>
+                        <span id="title"><slot /></span>
+                        <button tabindex={-1} id="close" title="Close" onClick={() => this.close()}>
+                            <ion-icon name="close-outline"></ion-icon>
+                        </button>
+                    </header>
+                    <slot />
+                </dialog>
+            </Host>)
+    }
+}

--- a/elements/src/components/pos-dialog/pos-dialog.tsx
+++ b/elements/src/components/pos-dialog/pos-dialog.tsx
@@ -1,5 +1,8 @@
 import { Component, Host, h, Method } from '@stencil/core';
 
+/**
+ * Styled wrapper around native dialog element, with slots `dialog-title` and `dialog-content`
+ */
 @Component({
   tag: 'pos-dialog',
   styleUrl: 'pos-dialog.css',

--- a/elements/src/components/pos-dialog/pos-dialog.tsx
+++ b/elements/src/components/pos-dialog/pos-dialog.tsx
@@ -26,9 +26,7 @@ export class PosDialog {
       <Host>
         <dialog ref={el => (this.dialog = el as HTMLDialogElement)}>
           <header>
-            <span id="title">
-              <slot name="title" />
-            </span>
+            <slot name="title" />
             <button tabindex={-1} id="close" title="Close" onClick={() => this.close()}>
               <ion-icon name="close-outline"></ion-icon>
             </button>

--- a/elements/src/components/pos-dialog/pos-dialog.tsx
+++ b/elements/src/components/pos-dialog/pos-dialog.tsx
@@ -1,7 +1,7 @@
 import { Component, Host, h, Method } from '@stencil/core';
 
 /**
- * Styled wrapper around native dialog element, with slots `dialog-title` and `dialog-content`
+ * Styled wrapper around native dialog element, with slots `title` and `content`
  */
 @Component({
   tag: 'pos-dialog',
@@ -27,13 +27,13 @@ export class PosDialog {
         <dialog ref={el => (this.dialog = el as HTMLDialogElement)}>
           <header>
             <span id="title">
-              <slot name="dialog-title" />
+              <slot name="title" />
             </span>
             <button tabindex={-1} id="close" title="Close" onClick={() => this.close()}>
               <ion-icon name="close-outline"></ion-icon>
             </button>
           </header>
-          <slot name="dialog-content" />
+          <slot name="content" />
         </dialog>
       </Host>
     );

--- a/elements/src/components/pos-dialog/pos-dialog.tsx
+++ b/elements/src/components/pos-dialog/pos-dialog.tsx
@@ -1,36 +1,38 @@
-import { Component, Host, h, Prop, Method } from '@stencil/core';
+import { Component, Host, h, Method } from '@stencil/core';
 
 @Component({
-    tag: 'pos-dialog',
-    styleUrl: 'pos-dialog.css',
-    shadow: true,
+  tag: 'pos-dialog',
+  styleUrl: 'pos-dialog.css',
+  shadow: true,
 })
 export class PosDialog {
+  private dialog: HTMLDialogElement;
 
-    private dialog: HTMLDialogElement;
+  @Method()
+  async showModal() {
+    this.dialog.showModal();
+  }
 
-    @Method()
-    async showModal() {
-        this.dialog.showModal();
-    }
+  @Method()
+  async close() {
+    this.dialog.close();
+  }
 
-    @Method()
-    async close() {
-        this.dialog.close();
-    }
-
-    render() {
-        return (
-            <Host>
-                <dialog ref={el => (this.dialog = el as HTMLDialogElement)} >
-                    <header>
-                        <span id="title"><slot /></span>
-                        <button tabindex={-1} id="close" title="Close" onClick={() => this.close()}>
-                            <ion-icon name="close-outline"></ion-icon>
-                        </button>
-                    </header>
-                    <slot />
-                </dialog>
-            </Host>)
-    }
+  render() {
+    return (
+      <Host>
+        <dialog ref={el => (this.dialog = el as HTMLDialogElement)}>
+          <header>
+            <span id="title">
+              <slot />
+            </span>
+            <button tabindex={-1} id="close" title="Close" onClick={() => this.close()}>
+              <ion-icon name="close-outline"></ion-icon>
+            </button>
+          </header>
+          <slot />
+        </dialog>
+      </Host>
+    );
+  }
 }

--- a/elements/src/components/pos-dialog/pos-dialog.tsx
+++ b/elements/src/components/pos-dialog/pos-dialog.tsx
@@ -24,13 +24,13 @@ export class PosDialog {
         <dialog ref={el => (this.dialog = el as HTMLDialogElement)}>
           <header>
             <span id="title">
-              <slot />
+              <slot name="dialog-title" />
             </span>
             <button tabindex={-1} id="close" title="Close" onClick={() => this.close()}>
               <ion-icon name="close-outline"></ion-icon>
             </button>
           </header>
-          <slot />
+          <slot name="dialog-content" />
         </dialog>
       </Host>
     );

--- a/elements/src/components/pos-dialog/test/pos-dialog.spec.tsx
+++ b/elements/src/components/pos-dialog/test/pos-dialog.spec.tsx
@@ -1,0 +1,52 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { screen } from '@testing-library/dom';
+import { PosDialog } from '../pos-dialog';
+
+describe('pos-dialog', () => {
+  it('renders a dialog with the given slot content', async () => {
+    const page = await newSpecPage({
+      components: [PosDialog],
+      html: `<pos-dialog><span slot="dialog-title">Title</span><span slot="dialog-content">Content</span></pos-dialog>`,
+    });
+    expect(page.root).toEqualHtml(`
+<pos-dialog>
+    <mock:shadow-root>
+        <dialog>
+            <header>
+                <span id="title">
+                    <slot name="dialog-title"/>
+                </span>
+                <button tabindex="-1" id="close" title="Close">
+                    <ion-icon name="close-outline"></ion-icon>
+                </button>
+            </header>
+            <slot name="dialog-content"/>
+        </dialog>
+    </mock:shadow-root>
+    <span slot="dialog-title">
+        Title
+    </span>
+    <span slot="dialog-content">
+        Content
+    </span>
+</pos-dialog>
+    `);
+  });
+
+  it('closes the modal dialog, when the close button is clicked', async () => {
+    const page = await newSpecPage({
+      components: [PosDialog],
+      html: `<pos-dialog><span slot="dialog-title">Title</span><span slot="dialog-content">Content</span></pos-dialog>`,
+      supportsShadowDom: false,
+    });
+
+    const dialog = page.root.querySelector('dialog');
+    dialog.close = jest.fn();
+
+    const closeButton = screen.getByTitle('Close');
+    closeButton.click();
+
+    expect(dialog.close).toHaveBeenCalled();
+  });
+
+});

--- a/elements/src/components/pos-dialog/test/pos-dialog.spec.tsx
+++ b/elements/src/components/pos-dialog/test/pos-dialog.spec.tsx
@@ -13,9 +13,7 @@ describe('pos-dialog', () => {
 <pos-dialog>
         <dialog>
             <header>
-                <span id="title">
-                    <span slot="title">Title</span>
-                </span>
+                <span slot="title">Title</span>
                 <button tabindex="-1" id="close" title="Close">
                     <ion-icon name="close-outline"></ion-icon>
                 </button>

--- a/elements/src/components/pos-dialog/test/pos-dialog.spec.tsx
+++ b/elements/src/components/pos-dialog/test/pos-dialog.spec.tsx
@@ -7,28 +7,21 @@ describe('pos-dialog', () => {
     const page = await newSpecPage({
       components: [PosDialog],
       html: `<pos-dialog><span slot="title">Title</span><span slot="content">Content</span></pos-dialog>`,
+      supportsShadowDom: false
     });
     expect(page.root).toEqualHtml(`
 <pos-dialog>
-    <mock:shadow-root>
         <dialog>
             <header>
                 <span id="title">
-                    <slot name="title"/>
+                    <span slot="title">Title</span>
                 </span>
                 <button tabindex="-1" id="close" title="Close">
                     <ion-icon name="close-outline"></ion-icon>
                 </button>
             </header>
-            <slot name="content"/>
+            <span slot="content">Content</span>
         </dialog>
-    </mock:shadow-root>
-    <span slot="title">
-        Title
-    </span>
-    <span slot="content">
-        Content
-    </span>
 </pos-dialog>
     `);
   });

--- a/elements/src/components/pos-dialog/test/pos-dialog.spec.tsx
+++ b/elements/src/components/pos-dialog/test/pos-dialog.spec.tsx
@@ -33,6 +33,36 @@ describe('pos-dialog', () => {
     `);
   });
 
+  it('showModal method calls showModal of the underlying dialog', async () => {
+    const page = await newSpecPage({
+      components: [PosDialog],
+      html: `<pos-dialog><span slot="dialog-title">Title</span><span slot="dialog-content">Content</span></pos-dialog>`,
+      supportsShadowDom: false,
+    });
+
+    const dialog = page.root.querySelector('dialog');
+    dialog.showModal = jest.fn();
+
+    page.rootInstance.showModal()
+
+    expect(dialog.showModal).toHaveBeenCalled();
+  });
+
+  it('close method closes the modal dialog', async () => {
+    const page = await newSpecPage({
+      components: [PosDialog],
+      html: `<pos-dialog><span slot="dialog-title">Title</span><span slot="dialog-content">Content</span></pos-dialog>`,
+      supportsShadowDom: false,
+    });
+
+    const dialog = page.root.querySelector('dialog');
+    dialog.close = jest.fn();
+
+    page.rootInstance.close()
+
+    expect(dialog.close).toHaveBeenCalled();
+  });
+
   it('closes the modal dialog, when the close button is clicked', async () => {
     const page = await newSpecPage({
       components: [PosDialog],

--- a/elements/src/components/pos-dialog/test/pos-dialog.spec.tsx
+++ b/elements/src/components/pos-dialog/test/pos-dialog.spec.tsx
@@ -6,7 +6,7 @@ describe('pos-dialog', () => {
   it('renders a dialog with the given slot content', async () => {
     const page = await newSpecPage({
       components: [PosDialog],
-      html: `<pos-dialog><span slot="dialog-title">Title</span><span slot="dialog-content">Content</span></pos-dialog>`,
+      html: `<pos-dialog><span slot="title">Title</span><span slot="content">Content</span></pos-dialog>`,
     });
     expect(page.root).toEqualHtml(`
 <pos-dialog>
@@ -14,19 +14,19 @@ describe('pos-dialog', () => {
         <dialog>
             <header>
                 <span id="title">
-                    <slot name="dialog-title"/>
+                    <slot name="title"/>
                 </span>
                 <button tabindex="-1" id="close" title="Close">
                     <ion-icon name="close-outline"></ion-icon>
                 </button>
             </header>
-            <slot name="dialog-content"/>
+            <slot name="content"/>
         </dialog>
     </mock:shadow-root>
-    <span slot="dialog-title">
+    <span slot="title">
         Title
     </span>
-    <span slot="dialog-content">
+    <span slot="content">
         Content
     </span>
 </pos-dialog>
@@ -36,7 +36,7 @@ describe('pos-dialog', () => {
   it('showModal method calls showModal of the underlying dialog', async () => {
     const page = await newSpecPage({
       components: [PosDialog],
-      html: `<pos-dialog><span slot="dialog-title">Title</span><span slot="dialog-content">Content</span></pos-dialog>`,
+      html: `<pos-dialog><span slot="title">Title</span><span slot="content">Content</span></pos-dialog>`,
       supportsShadowDom: false,
     });
 
@@ -51,7 +51,7 @@ describe('pos-dialog', () => {
   it('close method closes the modal dialog', async () => {
     const page = await newSpecPage({
       components: [PosDialog],
-      html: `<pos-dialog><span slot="dialog-title">Title</span><span slot="dialog-content">Content</span></pos-dialog>`,
+      html: `<pos-dialog><span slot="title">Title</span><span slot="content">Content</span></pos-dialog>`,
       supportsShadowDom: false,
     });
 
@@ -66,7 +66,7 @@ describe('pos-dialog', () => {
   it('closes the modal dialog, when the close button is clicked', async () => {
     const page = await newSpecPage({
       components: [PosDialog],
-      html: `<pos-dialog><span slot="dialog-title">Title</span><span slot="dialog-content">Content</span></pos-dialog>`,
+      html: `<pos-dialog><span slot="title">Title</span><span slot="content">Content</span></pos-dialog>`,
       supportsShadowDom: false,
     });
 

--- a/elements/src/components/pos-login-form/pos-login-form.tsx
+++ b/elements/src/components/pos-login-form/pos-login-form.tsx
@@ -11,6 +11,9 @@ export class PosLoginForm {
 
   @State() canSubmit: boolean = true;
 
+  /**
+   * Emits the selected IDP URL to use for login
+   */
   @Event({ eventName: 'idpUrlSelected' }) idpUrlSelected: EventEmitter;
   @Event({ eventName: 'pod-os:error' }) errorEmitter: EventEmitter;
 

--- a/elements/src/components/pos-login-form/pos-login-form.tsx
+++ b/elements/src/components/pos-login-form/pos-login-form.tsx
@@ -7,7 +7,7 @@ import { Component, Event, EventEmitter, h, Prop, State, Watch } from '@stencil/
   },
 })
 export class PosLoginForm {
-  @State() idpUrl: string = "http://localhost:3000";
+  @State() idpUrl: string = "";
 
   @State() canSubmit: boolean = true;
 

--- a/elements/src/components/pos-login-form/pos-login-form.tsx
+++ b/elements/src/components/pos-login-form/pos-login-form.tsx
@@ -14,8 +14,7 @@ export class PosLoginForm {
   /**
    * Emits the selected IDP URL to use for login
    */
-  @Event({ eventName: 'idpUrlSelected' }) idpUrlSelected: EventEmitter;
-  @Event({ eventName: 'pod-os:error' }) errorEmitter: EventEmitter;
+  @Event({ eventName: 'pod-os:idp-url-selected' }) idpUrlSelected: EventEmitter;
 
   @Watch('idpUrl')
   validate() {
@@ -24,7 +23,7 @@ export class PosLoginForm {
 
   render(): any {
     return (
-      <form method="dialog" onSubmit={e => this.handleSubmit(e)}>
+      <form method="dialog" onSubmit={() => this.handleSubmit()}>
         <label htmlFor="idpUrl">URL</label>
         <input id="idpUrl" type="text" value={this.idpUrl} onInput={e => this.handleChange(e)} />
         <input id="login" type="submit" value="Login" disabled={!this.canSubmit} />
@@ -37,13 +36,8 @@ export class PosLoginForm {
     this.idpUrl = event.target.value;
   }
 
-  async handleSubmit(event) {
-    try {
+  async handleSubmit() {
       this.idpUrlSelected.emit(this.idpUrl);
-    } catch (error) {
-      event.preventDefault();
-      this.errorEmitter.emit(error);
-    }
   }
 
 }

--- a/elements/src/components/pos-login-form/pos-login-form.tsx
+++ b/elements/src/components/pos-login-form/pos-login-form.tsx
@@ -1,0 +1,46 @@
+import { Component, Event, EventEmitter, h, Prop, State, Watch } from '@stencil/core';
+
+@Component({
+  tag: 'pos-login-form',
+  shadow: {
+    delegatesFocus: true,
+  },
+})
+export class PosLoginForm {
+  @State() idpUrl: string = "http://localhost:3000";
+
+  @State() canSubmit: boolean = true;
+
+  @Event({ eventName: 'idpUrlSelected' }) idpUrlSelected: EventEmitter;
+  @Event({ eventName: 'pod-os:error' }) errorEmitter: EventEmitter;
+
+  @Watch('idpUrl')
+  validate() {
+    this.canSubmit = Boolean(this.idpUrl);
+  }
+
+  render(): any {
+    return (
+      <form method="dialog" onSubmit={e => this.handleSubmit(e)}>
+        <label htmlFor="idpUrl">URL</label>
+        <input id="idpUrl" type="text" value={this.idpUrl} onInput={e => this.handleChange(e)} />
+        <input id="login" type="submit" value="Login" disabled={!this.canSubmit} />
+      </form>
+    );
+  }
+
+  handleChange(event) {
+    this.validate()
+    this.idpUrl = event.target.value;
+  }
+
+  async handleSubmit(event) {
+    try {
+      this.idpUrlSelected.emit(this.idpUrl);
+    } catch (error) {
+      event.preventDefault();
+      this.errorEmitter.emit(error);
+    }
+  }
+
+}

--- a/elements/src/components/pos-login-form/pos-login-form.tsx
+++ b/elements/src/components/pos-login-form/pos-login-form.tsx
@@ -25,8 +25,14 @@ export class PosLoginForm {
     return (
       <form method="dialog" onSubmit={() => this.handleSubmit()}>
         <label htmlFor="idpUrl">URL</label>
-        <input id="idpUrl" type="text" value={this.idpUrl} onInput={e => this.handleChange(e)} />
+        <input id="idpUrl" type="text" value={this.idpUrl} onInput={e => this.handleChange(e)} list="suggestedIssuers" />
         <input id="login" type="submit" value="Login" disabled={!this.canSubmit} />
+        <datalist id="suggestedIssuers">
+          <option value="https://solidcommunity.net">Solid Community</option>
+          <option value="https://solidweb.org">Solid Web</option>
+          <option value="https://inrupt.net">Inrupt.net</option>
+          <option value="https://login.inrupt.com">pod.Inrupt.com</option>
+        </datalist>
       </form>
     );
   }

--- a/elements/src/components/pos-login/pos-login.spec.tsx
+++ b/elements/src/components/pos-login/pos-login.spec.tsx
@@ -18,6 +18,12 @@ describe('pos-login', () => {
         <ion-button>
           Login
         </ion-button>
+        <pos-dialog>
+          <span slot="title">
+            Please enter your Identity Provider URL
+          </span>
+          <pos-login-form slot="content"></pos-login-form>
+        </pos-dialog>
       </mock:shadow-root>
     </pos-login>
   `);
@@ -42,6 +48,12 @@ describe('pos-login', () => {
         <ion-button>
           Logout
         </ion-button>
+        <pos-dialog>
+        <span slot="title">
+          Please enter your Identity Provider URL
+        </span>
+        <pos-login-form slot="content"></pos-login-form>
+      </pos-dialog>
       </mock:shadow-root>
     </pos-login>
   `);

--- a/elements/src/components/pos-login/pos-login.tsx
+++ b/elements/src/components/pos-login/pos-login.tsx
@@ -52,8 +52,8 @@ export class PosLogin {
         {!session.state.isLoggedIn && <ion-button onClick={() => this.openDialog()}>Login</ion-button>}
         {session.state.isLoggedIn && <ion-button onClick={() => this.logout()}>Logout</ion-button>}
         <pos-dialog ref={el => (this.dialog = el as HTMLPosDialogElement)}>
-          <span>Please enter your Identity Provider URL</span>
-          <pos-login-form  onIdpUrlSelected={ev=>this.login(ev)} />
+          <span slot="dialog-title">Please enter your Identity Provider URL</span>
+          <pos-login-form  onIdpUrlSelected={ev=>this.login(ev)} slot="dialog-content"/>
         </pos-dialog>
       </Host>
     );

--- a/elements/src/components/pos-login/pos-login.tsx
+++ b/elements/src/components/pos-login/pos-login.tsx
@@ -1,5 +1,5 @@
 import { PodOS } from '@pod-os/core';
-import { Component, Event, EventEmitter, h, Host, State } from '@stencil/core';
+import { Component, Event, EventEmitter, h, Host, Listen, State } from '@stencil/core';
 
 import session from '../../store/session';
 
@@ -21,13 +21,19 @@ export class PosLogin {
     this.os = os;
   };
 
-  login() {
-    const idp = session.state.getIdpUrl();
-    this.os.login(idp);
+  login(event: CustomEvent<string>) {
+    const idpUrl = event.detail
+    this.os.login(idpUrl);
   }
 
   logout() {
     this.os.logout();
+  }
+
+  private dialog: HTMLPosDialogElement;
+
+  openDialog() {
+    this.dialog.showModal()
   }
 
   render() {
@@ -43,8 +49,12 @@ export class PosLogin {
         ) : (
           ''
         )}
-        {!session.state.isLoggedIn && <ion-button onClick={() => this.login()}>Login</ion-button>}
+        {!session.state.isLoggedIn && <ion-button onClick={() => this.openDialog()}>Login</ion-button>}
         {session.state.isLoggedIn && <ion-button onClick={() => this.logout()}>Logout</ion-button>}
+        <pos-dialog ref={el => (this.dialog = el as HTMLPosDialogElement)}>
+          <span>Please enter your Identity Provider URL</span>
+          <pos-login-form  onIdpUrlSelected={ev=>this.login(ev)} />
+        </pos-dialog>
       </Host>
     );
   }

--- a/elements/src/components/pos-login/pos-login.tsx
+++ b/elements/src/components/pos-login/pos-login.tsx
@@ -52,8 +52,8 @@ export class PosLogin {
         {!session.state.isLoggedIn && <ion-button onClick={() => this.openDialog()}>Login</ion-button>}
         {session.state.isLoggedIn && <ion-button onClick={() => this.logout()}>Logout</ion-button>}
         <pos-dialog ref={el => (this.dialog = el as HTMLPosDialogElement)}>
-          <span slot="dialog-title">Please enter your Identity Provider URL</span>
-          <pos-login-form  onIdpUrlSelected={ev=>this.login(ev)} slot="dialog-content"/>
+          <span slot="title">Please enter your Identity Provider URL</span>
+          <pos-login-form  onPod-os:idp-url-selected={ev=>this.login(ev)} slot="content"/>
         </pos-dialog>
       </Host>
     );

--- a/elements/src/store/getIdpUrl.ts
+++ b/elements/src/store/getIdpUrl.ts
@@ -1,1 +1,0 @@
-export const getIdpUrl = () => prompt('Please enter your Identity Provider URL', 'http://localhost:3000');

--- a/elements/src/store/session.ts
+++ b/elements/src/store/session.ts
@@ -1,8 +1,6 @@
 import { createStore } from '@stencil/store';
-import { getIdpUrl } from './getIdpUrl';
 
 const store = createStore({
-  getIdpUrl,
   isLoggedIn: false,
   webId: '',
 });

--- a/storybook/stories/inputs/5_pos-dialog.stories.mdx
+++ b/storybook/stories/inputs/5_pos-dialog.stories.mdx
@@ -1,0 +1,30 @@
+import {html} from "lit-html";
+
+import {
+  Canvas,
+  Meta,
+  Story
+} from '@storybook/addon-docs/blocks';
+
+<Meta
+  title="Inputs"
+/>
+
+## pos-dialog
+
+Styled wrapper around native dialog element
+
+<Canvas
+  withSource="open">
+  <Story
+    name="pos-dialog"
+  >
+    {() => html`
+<button type="button" onClick="this.parentNode.querySelector('pos-dialog').showModal()">Click to open dialog</button>
+  <pos-dialog>
+      <span slot="dialog-title">Title</span>
+      <div slot="dialog-content">Content</div>
+  </pos-dialog>
+    `}
+  </Story>
+</Canvas>

--- a/storybook/stories/inputs/5_pos-dialog.stories.mdx
+++ b/storybook/stories/inputs/5_pos-dialog.stories.mdx
@@ -22,8 +22,8 @@ Styled wrapper around native dialog element
     {() => html`
 <button type="button" onClick="this.parentNode.querySelector('pos-dialog').showModal()">Click to open dialog</button>
   <pos-dialog>
-      <span slot="dialog-title">Title</span>
-      <div slot="dialog-content">Content</div>
+      <span slot="title">Title</span>
+      <div slot="content">Content</div>
   </pos-dialog>
     `}
   </Story>


### PR DESCRIPTION
WIP to implement part of #21 - using a modal dialog instead of prompt allows browser's built-in autocomplete to be used and provided platform for further features

- [x] Create modal in pos-login & display modal on click - now waiting on #23 
- [x] Duplicate functionality of getIdpUrl, i.e. a single input textbox with a default value
- [ ] Style pos-login-form
- [ ] Tests have been written
  - [ ] all new code is covered by unit tests
    - [ ] Add test for pos-login-form
    - [ ] Edit tests for pos-login
      - [x] pos-login.spec.tsx
      - [ ] pos-login.integration.spec.tsx
  - [ ] the happy path of a new feature is covered by an end-to-end test
    - [ ] Add new e2e test in https://github.com/pod-os/PodOS/tree/main/apps/tests
  - [x] manual explorative tests have been performed
- [x] all dependencies are updated to the latest patch version at minimum
  - Done upstream
- [ ] the [CI pipeline](https://github.com/pod-os/PodOS/actions) passes
- [x] documentation is up-to-date
    - [x] TSDoc style comments on important functions, properties and events
      - Documented `onIdpUrlSelected` event
    - [x] stories for new PodOS elements have been added to [storybook](../../storybook)
      - [x] No changes required to https://github.com/pod-os/PodOS/blob/main/storybook/stories/login/1_pos-login.stories.mdx
  - [x] Readme.md files of PodOS elements have been re-generated
    - `npm run build` in elements
  - [x] architectural decisions are documented as an [ADR](../decisions/0000-use-markdown-architectural-decision-records.md)
    - No new architectural decisions
  - [x] Changelogs are updated according to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
- [x] Possibly rename `onIdpUrlSelected` event


Edited 29 Jul to reduce scope of this PR. See #21 for backlog checklist