### PR TITLE
refactor: split out pos-dialog

### DIFF
--- a/docs/elements/apps/pos-app-browser/readme.md
+++ b/docs/elements/apps/pos-app-browser/readme.md
@@ -51,7 +51,9 @@ graph TD;
   pos-router --> pos-resource
   pos-router --> pos-type-router
   pos-add-new-thing --> ion-icon
+  pos-add-new-thing --> pos-dialog
   pos-add-new-thing --> pos-new-thing-form
+  pos-dialog --> ion-icon
   pos-new-thing-form --> pos-select-term
   pos-navigation-bar --> ion-searchbar
   ion-searchbar --> ion-icon

--- a/docs/elements/components/pos-add-new-thing/readme.md
+++ b/docs/elements/components/pos-add-new-thing/readme.md
@@ -21,13 +21,16 @@
 ### Depends on
 
 - ion-icon
+- [pos-dialog](../pos-dialog)
 - [pos-new-thing-form](../pos-new-thing-form)
 
 ### Graph
 ```mermaid
 graph TD;
   pos-add-new-thing --> ion-icon
+  pos-add-new-thing --> pos-dialog
   pos-add-new-thing --> pos-new-thing-form
+  pos-dialog --> ion-icon
   pos-new-thing-form --> pos-select-term
   pos-router --> pos-add-new-thing
   style pos-add-new-thing fill:#f9f,stroke:#333,stroke-width:4px

--- a/docs/elements/components/pos-dialog/readme.md
+++ b/docs/elements/components/pos-dialog/readme.md
@@ -1,0 +1,55 @@
+# pos-dialog
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Overview
+
+Styled wrapper around native dialog element, with slots `dialog-title` and `dialog-content`
+
+## Methods
+
+### `close() => Promise<void>`
+
+
+
+#### Returns
+
+Type: `Promise<void>`
+
+
+
+### `showModal() => Promise<void>`
+
+
+
+#### Returns
+
+Type: `Promise<void>`
+
+
+
+
+## Dependencies
+
+### Used by
+
+ - [pos-add-new-thing](../pos-add-new-thing)
+
+### Depends on
+
+- ion-icon
+
+### Graph
+```mermaid
+graph TD;
+  pos-dialog --> ion-icon
+  pos-add-new-thing --> pos-dialog
+  style pos-dialog fill:#f9f,stroke:#333,stroke-width:4px
+```
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/docs/elements/components/pos-dialog/readme.md
+++ b/docs/elements/components/pos-dialog/readme.md
@@ -7,7 +7,7 @@
 
 ## Overview
 
-Styled wrapper around native dialog element, with slots `dialog-title` and `dialog-content`
+Styled wrapper around native dialog element, with slots `title` and `content`
 
 ## Methods
 

--- a/docs/elements/components/pos-router/readme.md
+++ b/docs/elements/components/pos-router/readme.md
@@ -26,7 +26,9 @@ graph TD;
   pos-router --> pos-resource
   pos-router --> pos-type-router
   pos-add-new-thing --> ion-icon
+  pos-add-new-thing --> pos-dialog
   pos-add-new-thing --> pos-new-thing-form
+  pos-dialog --> ion-icon
   pos-new-thing-form --> pos-select-term
   pos-navigation-bar --> ion-searchbar
   ion-searchbar --> ion-icon

--- a/elements/CHANGELOG.md
+++ b/elements/CHANGELOG.md
@@ -6,9 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Added
+
+- [pos-dialog]: A dialog component with a common style
+
 ### Changed
 
 - [pos-app](../docs/elements/components/pos-app): After login `pos-app` now loads the preferences file that is linked in the user's WebID profile (if any).
+- [pos-add-new-thing]: Refactored to use [pos-dialog]
+
+[pos-add-new-thing]: ../docs/elements/components/pos-add-new-thing
+[pos-dialog]: ../docs/elements/components/pos-dialog
 
 ## 0.13.0
 

--- a/elements/CHANGELOG.md
+++ b/elements/CHANGELOG.md
@@ -8,15 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
-- [pos-dialog]: A dialog component with a common style
+- [pos-dialog](../docs/elements/components/pos-dialog): A dialog component with a common style
 
 ### Changed
 
 - [pos-app](../docs/elements/components/pos-app): After login `pos-app` now loads the preferences file that is linked in the user's WebID profile (if any).
-- [pos-add-new-thing]: Refactored to use [pos-dialog]
-
-[pos-add-new-thing]: ../docs/elements/components/pos-add-new-thing
-[pos-dialog]: ../docs/elements/components/pos-dialog
 
 ## 0.13.0
 

--- a/elements/src/components.d.ts
+++ b/elements/src/components.d.ts
@@ -31,6 +31,9 @@ export namespace Components {
     }
     interface PosDescription {
     }
+    /**
+     * Styled wrapper around native dialog element, with slots `dialog-title` and `dialog-content`
+     */
     interface PosDialog {
         "close": () => Promise<void>;
         "showModal": () => Promise<void>;
@@ -255,6 +258,9 @@ declare global {
         prototype: HTMLPosDescriptionElement;
         new (): HTMLPosDescriptionElement;
     };
+    /**
+     * Styled wrapper around native dialog element, with slots `dialog-title` and `dialog-content`
+     */
     interface HTMLPosDialogElement extends Components.PosDialog, HTMLStencilElement {
     }
     var HTMLPosDialogElement: {
@@ -452,6 +458,9 @@ declare namespace LocalJSX {
     interface PosDescription {
         "onPod-os:resource"?: (event: PosDescriptionCustomEvent<any>) => void;
     }
+    /**
+     * Styled wrapper around native dialog element, with slots `dialog-title` and `dialog-content`
+     */
     interface PosDialog {
     }
     interface PosDocument {
@@ -593,6 +602,9 @@ declare module "@stencil/core" {
             "pos-container-contents": LocalJSX.PosContainerContents & JSXBase.HTMLAttributes<HTMLPosContainerContentsElement>;
             "pos-container-item": LocalJSX.PosContainerItem & JSXBase.HTMLAttributes<HTMLPosContainerItemElement>;
             "pos-description": LocalJSX.PosDescription & JSXBase.HTMLAttributes<HTMLPosDescriptionElement>;
+            /**
+             * Styled wrapper around native dialog element, with slots `dialog-title` and `dialog-content`
+             */
             "pos-dialog": LocalJSX.PosDialog & JSXBase.HTMLAttributes<HTMLPosDialogElement>;
             "pos-document": LocalJSX.PosDocument & JSXBase.HTMLAttributes<HTMLPosDocumentElement>;
             "pos-error-toast": LocalJSX.PosErrorToast & JSXBase.HTMLAttributes<HTMLPosErrorToastElement>;

--- a/elements/src/components.d.ts
+++ b/elements/src/components.d.ts
@@ -31,6 +31,10 @@ export namespace Components {
     }
     interface PosDescription {
     }
+    interface PosDialog {
+        "close": () => Promise<void>;
+        "showModal": () => Promise<void>;
+    }
     interface PosDocument {
         "alt": string;
         "src": string;
@@ -251,6 +255,12 @@ declare global {
         prototype: HTMLPosDescriptionElement;
         new (): HTMLPosDescriptionElement;
     };
+    interface HTMLPosDialogElement extends Components.PosDialog, HTMLStencilElement {
+    }
+    var HTMLPosDialogElement: {
+        prototype: HTMLPosDialogElement;
+        new (): HTMLPosDialogElement;
+    };
     interface HTMLPosDocumentElement extends Components.PosDocument, HTMLStencilElement {
     }
     var HTMLPosDocumentElement: {
@@ -378,6 +388,7 @@ declare global {
         "pos-container-contents": HTMLPosContainerContentsElement;
         "pos-container-item": HTMLPosContainerItemElement;
         "pos-description": HTMLPosDescriptionElement;
+        "pos-dialog": HTMLPosDialogElement;
         "pos-document": HTMLPosDocumentElement;
         "pos-error-toast": HTMLPosErrorToastElement;
         "pos-image": HTMLPosImageElement;
@@ -440,6 +451,8 @@ declare namespace LocalJSX {
     }
     interface PosDescription {
         "onPod-os:resource"?: (event: PosDescriptionCustomEvent<any>) => void;
+    }
+    interface PosDialog {
     }
     interface PosDocument {
         "alt"?: string;
@@ -542,6 +555,7 @@ declare namespace LocalJSX {
         "pos-container-contents": PosContainerContents;
         "pos-container-item": PosContainerItem;
         "pos-description": PosDescription;
+        "pos-dialog": PosDialog;
         "pos-document": PosDocument;
         "pos-error-toast": PosErrorToast;
         "pos-image": PosImage;
@@ -579,6 +593,7 @@ declare module "@stencil/core" {
             "pos-container-contents": LocalJSX.PosContainerContents & JSXBase.HTMLAttributes<HTMLPosContainerContentsElement>;
             "pos-container-item": LocalJSX.PosContainerItem & JSXBase.HTMLAttributes<HTMLPosContainerItemElement>;
             "pos-description": LocalJSX.PosDescription & JSXBase.HTMLAttributes<HTMLPosDescriptionElement>;
+            "pos-dialog": LocalJSX.PosDialog & JSXBase.HTMLAttributes<HTMLPosDialogElement>;
             "pos-document": LocalJSX.PosDocument & JSXBase.HTMLAttributes<HTMLPosDocumentElement>;
             "pos-error-toast": LocalJSX.PosErrorToast & JSXBase.HTMLAttributes<HTMLPosErrorToastElement>;
             "pos-image": LocalJSX.PosImage & JSXBase.HTMLAttributes<HTMLPosImageElement>;

--- a/elements/src/components.d.ts
+++ b/elements/src/components.d.ts
@@ -32,7 +32,7 @@ export namespace Components {
     interface PosDescription {
     }
     /**
-     * Styled wrapper around native dialog element, with slots `dialog-title` and `dialog-content`
+     * Styled wrapper around native dialog element, with slots `title` and `content`
      */
     interface PosDialog {
         "close": () => Promise<void>;
@@ -259,7 +259,7 @@ declare global {
         new (): HTMLPosDescriptionElement;
     };
     /**
-     * Styled wrapper around native dialog element, with slots `dialog-title` and `dialog-content`
+     * Styled wrapper around native dialog element, with slots `title` and `content`
      */
     interface HTMLPosDialogElement extends Components.PosDialog, HTMLStencilElement {
     }
@@ -459,7 +459,7 @@ declare namespace LocalJSX {
         "onPod-os:resource"?: (event: PosDescriptionCustomEvent<any>) => void;
     }
     /**
-     * Styled wrapper around native dialog element, with slots `dialog-title` and `dialog-content`
+     * Styled wrapper around native dialog element, with slots `title` and `content`
      */
     interface PosDialog {
     }
@@ -603,7 +603,7 @@ declare module "@stencil/core" {
             "pos-container-item": LocalJSX.PosContainerItem & JSXBase.HTMLAttributes<HTMLPosContainerItemElement>;
             "pos-description": LocalJSX.PosDescription & JSXBase.HTMLAttributes<HTMLPosDescriptionElement>;
             /**
-             * Styled wrapper around native dialog element, with slots `dialog-title` and `dialog-content`
+             * Styled wrapper around native dialog element, with slots `title` and `content`
              */
             "pos-dialog": LocalJSX.PosDialog & JSXBase.HTMLAttributes<HTMLPosDialogElement>;
             "pos-document": LocalJSX.PosDocument & JSXBase.HTMLAttributes<HTMLPosDocumentElement>;

--- a/elements/src/components/pos-add-new-thing/pos-add-new-thing.css
+++ b/elements/src/components/pos-add-new-thing/pos-add-new-thing.css
@@ -23,7 +23,3 @@ button#new:hover, button#new:focus {
   box-shadow: var(--shadow-sm);
 }
 
-pos-new-thing-form {
-  margin: var(--scale-3)
-}
-

--- a/elements/src/components/pos-add-new-thing/pos-add-new-thing.css
+++ b/elements/src/components/pos-add-new-thing/pos-add-new-thing.css
@@ -23,46 +23,6 @@ button#new:hover, button#new:focus {
   box-shadow: var(--shadow-sm);
 }
 
-dialog {
-  background-color: var(--pos-background-color);
-  border: none;
-  border-radius: var(--radius-md);
-  box-shadow: var(--shadow-md);
-  max-width: var(--width-xs);
-}
-
-dialog #title {
-  flex-grow: 1;
-  font-weight: var(--weight-light);
-  font-size: var(--scale-2);
-}
-
-dialog header {
-  display: flex;
-  flex-direction: row;
-  justify-content: start;
-  align-items: center;
-  gap: var(--scale-0);
-  border-bottom-style: inset;
-  padding-bottom: var(--scale-0);
-}
-
-button#close {
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border: none;
-  background: none;
-  font-size: var(--scale-3);
-  color: var(--color-grey-500);
-}
-
-button#close:hover {
-  color: var(--color-grey-800);
-}
-
-
 pos-new-thing-form {
   margin: var(--scale-3)
 }

--- a/elements/src/components/pos-add-new-thing/pos-add-new-thing.tsx
+++ b/elements/src/components/pos-add-new-thing/pos-add-new-thing.tsx
@@ -1,4 +1,4 @@
-import { Component, Host, h, Prop } from '@stencil/core';
+import { Component, Host, h, Listen, Prop } from '@stencil/core';
 
 @Component({
   tag: 'pos-add-new-thing',
@@ -12,6 +12,11 @@ export class PosAddNewThing {
 
   openDialog() {
     this.dialog.showModal();
+  }
+
+  @Listen('pod-os:link')
+  closeDialog(){
+    this.dialog.close()
   }
 
   render() {

--- a/elements/src/components/pos-add-new-thing/pos-add-new-thing.tsx
+++ b/elements/src/components/pos-add-new-thing/pos-add-new-thing.tsx
@@ -21,8 +21,8 @@ export class PosAddNewThing {
           <ion-icon name="add-circle-outline"></ion-icon>
         </button>
         <pos-dialog ref={el => (this.dialog = el as HTMLPosDialogElement)}>
-          <span slot="dialog-title">Add a new thing</span>
-          <pos-new-thing-form slot="dialog-content" referenceUri={this.referenceUri} />
+          <span slot="title">Add a new thing</span>
+          <pos-new-thing-form slot="content" referenceUri={this.referenceUri} />
         </pos-dialog>
       </Host>
     );

--- a/elements/src/components/pos-add-new-thing/pos-add-new-thing.tsx
+++ b/elements/src/components/pos-add-new-thing/pos-add-new-thing.tsx
@@ -21,8 +21,8 @@ export class PosAddNewThing {
           <ion-icon name="add-circle-outline"></ion-icon>
         </button>
         <pos-dialog ref={el => (this.dialog = el as HTMLPosDialogElement)}>
-          <span>Add a new thing</span>
-          <pos-new-thing-form referenceUri={this.referenceUri} />
+          <span slot="dialog-title">Add a new thing</span>
+          <pos-new-thing-form slot="dialog-content" referenceUri={this.referenceUri} />
         </pos-dialog>
       </Host>
     );

--- a/elements/src/components/pos-add-new-thing/pos-add-new-thing.tsx
+++ b/elements/src/components/pos-add-new-thing/pos-add-new-thing.tsx
@@ -8,30 +8,22 @@ import { Component, Host, h, Prop } from '@stencil/core';
 export class PosAddNewThing {
   @Prop() referenceUri!: string;
 
-  private dialog: HTMLDialogElement;
+  private dialog: HTMLPosDialogElement;
 
   openDialog() {
     this.dialog.showModal();
   }
 
-  closeDialog() {
-    this.dialog.close();
-  }
   render() {
     return (
       <Host>
         <button id="new" title="Add a new thing" onClick={() => this.openDialog()}>
           <ion-icon name="add-circle-outline"></ion-icon>
         </button>
-        <dialog ref={el => (this.dialog = el as HTMLDialogElement)}>
-          <header>
-            <span id="title">Add a new thing</span>
-            <button tabindex={-1} id="close" title="Close" onClick={() => this.closeDialog()}>
-              <ion-icon name="close-outline"></ion-icon>
-            </button>
-          </header>
+        <pos-dialog ref={el => (this.dialog = el as HTMLPosDialogElement)}>
+          <span>Add a new thing</span>
           <pos-new-thing-form referenceUri={this.referenceUri} />
-        </dialog>
+        </pos-dialog>
       </Host>
     );
   }

--- a/elements/src/components/pos-add-new-thing/test/pos-add-new-thing.spec.tsx
+++ b/elements/src/components/pos-add-new-thing/test/pos-add-new-thing.spec.tsx
@@ -15,10 +15,10 @@ describe('pos-add-new-thing', () => {
             <ion-icon name="add-circle-outline"></ion-icon>
         </button>
         <pos-dialog>
-                <span slot="dialog-title">
+                <span slot="title">
                       Add a new thing
                 </span>
-            <pos-new-thing-form referenceUri="https://pod.test/" slot="dialog-content"/>
+            <pos-new-thing-form referenceUri="https://pod.test/" slot="content"/>
         </pos-dialog>
     </mock:shadow-root>
 </pos-add-new-thing>

--- a/elements/src/components/pos-add-new-thing/test/pos-add-new-thing.spec.tsx
+++ b/elements/src/components/pos-add-new-thing/test/pos-add-new-thing.spec.tsx
@@ -14,17 +14,12 @@ describe('pos-add-new-thing', () => {
         <button id="new" title="Add a new thing">
             <ion-icon name="add-circle-outline"></ion-icon>
         </button>
-        <dialog>
-            <header>
-                <span id="title">
-                  Add a new thing
+        <pos-dialog>
+                <span slot="dialog-title">
+                      Add a new thing
                 </span>
-                <button tabindex="-1" id="close" title="Close">
-                    <ion-icon name="close-outline"></ion-icon>
-                </button>
-            </header>
-            <pos-new-thing-form referenceUri="https://pod.test/" />
-        </dialog>
+            <pos-new-thing-form referenceUri="https://pod.test/" slot="dialog-content"/>
+        </pos-dialog>
     </mock:shadow-root>
 </pos-add-new-thing>
     `);
@@ -37,32 +32,12 @@ describe('pos-add-new-thing', () => {
       supportsShadowDom: false,
     });
 
-    const dialog = page.root.querySelector('dialog');
+    const dialog = page.root.querySelector('pos-dialog');
     dialog.showModal = jest.fn();
 
     const button = screen.getByTitle('Add a new thing');
     button.click();
 
     expect(dialog.showModal).toHaveBeenCalled();
-  });
-
-  it('closes the modal dialog, when the close button is clicked', async () => {
-    const page = await newSpecPage({
-      components: [PosAddNewThing],
-      html: `<pos-add-new-thing reference-uri="https://pod.test/"></pos-add-new-thing>`,
-      supportsShadowDom: false,
-    });
-
-    const dialog = page.root.querySelector('dialog');
-    dialog.showModal = jest.fn();
-    dialog.close = jest.fn();
-
-    const button = screen.getByTitle('Add a new thing');
-    button.click();
-
-    const closeButton = screen.getByTitle('Close');
-    closeButton.click();
-
-    expect(dialog.close).toHaveBeenCalled();
   });
 });

--- a/elements/src/components/pos-dialog/pos-dialog.css
+++ b/elements/src/components/pos-dialog/pos-dialog.css
@@ -27,6 +27,10 @@ dialog header {
   padding-bottom: var(--scale-0);
 }
 
+dialog [name='dialog-content']::slotted(*) {
+  margin: var(--scale-3);
+}
+
 button#close {
   cursor: pointer;
   display: flex;

--- a/elements/src/components/pos-dialog/pos-dialog.css
+++ b/elements/src/components/pos-dialog/pos-dialog.css
@@ -1,0 +1,57 @@
+:host {
+  font-family: var(--font-sans);
+  display: block;
+}
+
+button#new {
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  width: var(--scale-5);
+  height: var(--scale-5);
+  background-color: var(--pos-primary-color);
+  color: var(--color-grey-50);
+  font-size: var(--scale-6);
+  border-radius: var(--radius-xs);
+}
+
+dialog {
+  background-color: var(--pos-background-color);
+  border: none;
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-md);
+  max-width: var(--width-xs);
+}
+
+dialog #title {
+  flex-grow: 1;
+  font-weight: var(--weight-light);
+  font-size: var(--scale-2);
+}
+
+dialog header {
+  display: flex;
+  flex-direction: row;
+  justify-content: start;
+  align-items: center;
+  gap: var(--scale-0);
+  border-bottom-style: inset;
+  padding-bottom: var(--scale-0);
+}
+
+button#close {
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background: none;
+  font-size: var(--scale-3);
+  color: var(--color-grey-500);
+}
+
+button#close:hover {
+  color: var(--color-grey-800);
+}

--- a/elements/src/components/pos-dialog/pos-dialog.css
+++ b/elements/src/components/pos-dialog/pos-dialog.css
@@ -11,7 +11,7 @@ dialog {
   max-width: var(--width-xs);
 }
 
-dialog #title {
+dialog slot[name='title']::slotted(*) {
   flex-grow: 1;
   font-weight: var(--weight-light);
   font-size: var(--scale-2);

--- a/elements/src/components/pos-dialog/pos-dialog.css
+++ b/elements/src/components/pos-dialog/pos-dialog.css
@@ -27,7 +27,7 @@ dialog header {
   padding-bottom: var(--scale-0);
 }
 
-dialog [name='dialog-content']::slotted(*) {
+dialog [name='content']::slotted(*) {
   margin: var(--scale-3);
 }
 

--- a/elements/src/components/pos-dialog/pos-dialog.css
+++ b/elements/src/components/pos-dialog/pos-dialog.css
@@ -3,20 +3,6 @@
   display: block;
 }
 
-button#new {
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border: none;
-  width: var(--scale-5);
-  height: var(--scale-5);
-  background-color: var(--pos-primary-color);
-  color: var(--color-grey-50);
-  font-size: var(--scale-6);
-  border-radius: var(--radius-xs);
-}
-
 dialog {
   background-color: var(--pos-background-color);
   border: none;

--- a/elements/src/components/pos-dialog/pos-dialog.tsx
+++ b/elements/src/components/pos-dialog/pos-dialog.tsx
@@ -1,0 +1,36 @@
+import { Component, Host, h, Prop, Method } from '@stencil/core';
+
+@Component({
+    tag: 'pos-dialog',
+    styleUrl: 'pos-dialog.css',
+    shadow: true,
+})
+export class PosDialog {
+
+    private dialog: HTMLDialogElement;
+
+    @Method()
+    async showModal() {
+        this.dialog.showModal();
+    }
+
+    @Method()
+    async close() {
+        this.dialog.close();
+    }
+
+    render() {
+        return (
+            <Host>
+                <dialog ref={el => (this.dialog = el as HTMLDialogElement)} >
+                    <header>
+                        <span id="title"><slot /></span>
+                        <button tabindex={-1} id="close" title="Close" onClick={() => this.close()}>
+                            <ion-icon name="close-outline"></ion-icon>
+                        </button>
+                    </header>
+                    <slot />
+                </dialog>
+            </Host>)
+    }
+}

--- a/elements/src/components/pos-dialog/pos-dialog.tsx
+++ b/elements/src/components/pos-dialog/pos-dialog.tsx
@@ -1,5 +1,8 @@
 import { Component, Host, h, Method } from '@stencil/core';
 
+/**
+ * Styled wrapper around native dialog element, with slots `dialog-title` and `dialog-content`
+ */
 @Component({
   tag: 'pos-dialog',
   styleUrl: 'pos-dialog.css',

--- a/elements/src/components/pos-dialog/pos-dialog.tsx
+++ b/elements/src/components/pos-dialog/pos-dialog.tsx
@@ -26,9 +26,7 @@ export class PosDialog {
       <Host>
         <dialog ref={el => (this.dialog = el as HTMLDialogElement)}>
           <header>
-            <span id="title">
-              <slot name="title" />
-            </span>
+            <slot name="title" />
             <button tabindex={-1} id="close" title="Close" onClick={() => this.close()}>
               <ion-icon name="close-outline"></ion-icon>
             </button>

--- a/elements/src/components/pos-dialog/pos-dialog.tsx
+++ b/elements/src/components/pos-dialog/pos-dialog.tsx
@@ -1,7 +1,7 @@
 import { Component, Host, h, Method } from '@stencil/core';
 
 /**
- * Styled wrapper around native dialog element, with slots `dialog-title` and `dialog-content`
+ * Styled wrapper around native dialog element, with slots `title` and `content`
  */
 @Component({
   tag: 'pos-dialog',
@@ -27,13 +27,13 @@ export class PosDialog {
         <dialog ref={el => (this.dialog = el as HTMLDialogElement)}>
           <header>
             <span id="title">
-              <slot name="dialog-title" />
+              <slot name="title" />
             </span>
             <button tabindex={-1} id="close" title="Close" onClick={() => this.close()}>
               <ion-icon name="close-outline"></ion-icon>
             </button>
           </header>
-          <slot name="dialog-content" />
+          <slot name="content" />
         </dialog>
       </Host>
     );

--- a/elements/src/components/pos-dialog/pos-dialog.tsx
+++ b/elements/src/components/pos-dialog/pos-dialog.tsx
@@ -1,36 +1,38 @@
-import { Component, Host, h, Prop, Method } from '@stencil/core';
+import { Component, Host, h, Method } from '@stencil/core';
 
 @Component({
-    tag: 'pos-dialog',
-    styleUrl: 'pos-dialog.css',
-    shadow: true,
+  tag: 'pos-dialog',
+  styleUrl: 'pos-dialog.css',
+  shadow: true,
 })
 export class PosDialog {
+  private dialog: HTMLDialogElement;
 
-    private dialog: HTMLDialogElement;
+  @Method()
+  async showModal() {
+    this.dialog.showModal();
+  }
 
-    @Method()
-    async showModal() {
-        this.dialog.showModal();
-    }
+  @Method()
+  async close() {
+    this.dialog.close();
+  }
 
-    @Method()
-    async close() {
-        this.dialog.close();
-    }
-
-    render() {
-        return (
-            <Host>
-                <dialog ref={el => (this.dialog = el as HTMLDialogElement)} >
-                    <header>
-                        <span id="title"><slot /></span>
-                        <button tabindex={-1} id="close" title="Close" onClick={() => this.close()}>
-                            <ion-icon name="close-outline"></ion-icon>
-                        </button>
-                    </header>
-                    <slot />
-                </dialog>
-            </Host>)
-    }
+  render() {
+    return (
+      <Host>
+        <dialog ref={el => (this.dialog = el as HTMLDialogElement)}>
+          <header>
+            <span id="title">
+              <slot />
+            </span>
+            <button tabindex={-1} id="close" title="Close" onClick={() => this.close()}>
+              <ion-icon name="close-outline"></ion-icon>
+            </button>
+          </header>
+          <slot />
+        </dialog>
+      </Host>
+    );
+  }
 }

--- a/elements/src/components/pos-dialog/pos-dialog.tsx
+++ b/elements/src/components/pos-dialog/pos-dialog.tsx
@@ -24,13 +24,13 @@ export class PosDialog {
         <dialog ref={el => (this.dialog = el as HTMLDialogElement)}>
           <header>
             <span id="title">
-              <slot />
+              <slot name="dialog-title" />
             </span>
             <button tabindex={-1} id="close" title="Close" onClick={() => this.close()}>
               <ion-icon name="close-outline"></ion-icon>
             </button>
           </header>
-          <slot />
+          <slot name="dialog-content" />
         </dialog>
       </Host>
     );

--- a/elements/src/components/pos-dialog/test/pos-dialog.spec.tsx
+++ b/elements/src/components/pos-dialog/test/pos-dialog.spec.tsx
@@ -1,0 +1,52 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { screen } from '@testing-library/dom';
+import { PosDialog } from '../pos-dialog';
+
+describe('pos-dialog', () => {
+  it('renders a dialog with the given slot content', async () => {
+    const page = await newSpecPage({
+      components: [PosDialog],
+      html: `<pos-dialog><span slot="dialog-title">Title</span><span slot="dialog-content">Content</span></pos-dialog>`,
+    });
+    expect(page.root).toEqualHtml(`
+<pos-dialog>
+    <mock:shadow-root>
+        <dialog>
+            <header>
+                <span id="title">
+                    <slot name="dialog-title"/>
+                </span>
+                <button tabindex="-1" id="close" title="Close">
+                    <ion-icon name="close-outline"></ion-icon>
+                </button>
+            </header>
+            <slot name="dialog-content"/>
+        </dialog>
+    </mock:shadow-root>
+    <span slot="dialog-title">
+        Title
+    </span>
+    <span slot="dialog-content">
+        Content
+    </span>
+</pos-dialog>
+    `);
+  });
+
+  it('closes the modal dialog, when the close button is clicked', async () => {
+    const page = await newSpecPage({
+      components: [PosDialog],
+      html: `<pos-dialog><span slot="dialog-title">Title</span><span slot="dialog-content">Content</span></pos-dialog>`,
+      supportsShadowDom: false,
+    });
+
+    const dialog = page.root.querySelector('dialog');
+    dialog.close = jest.fn();
+
+    const closeButton = screen.getByTitle('Close');
+    closeButton.click();
+
+    expect(dialog.close).toHaveBeenCalled();
+  });
+
+});

--- a/elements/src/components/pos-dialog/test/pos-dialog.spec.tsx
+++ b/elements/src/components/pos-dialog/test/pos-dialog.spec.tsx
@@ -13,9 +13,7 @@ describe('pos-dialog', () => {
 <pos-dialog>
         <dialog>
             <header>
-                <span id="title">
-                    <span slot="title">Title</span>
-                </span>
+                <span slot="title">Title</span>
                 <button tabindex="-1" id="close" title="Close">
                     <ion-icon name="close-outline"></ion-icon>
                 </button>

--- a/elements/src/components/pos-dialog/test/pos-dialog.spec.tsx
+++ b/elements/src/components/pos-dialog/test/pos-dialog.spec.tsx
@@ -7,28 +7,21 @@ describe('pos-dialog', () => {
     const page = await newSpecPage({
       components: [PosDialog],
       html: `<pos-dialog><span slot="title">Title</span><span slot="content">Content</span></pos-dialog>`,
+      supportsShadowDom: false
     });
     expect(page.root).toEqualHtml(`
 <pos-dialog>
-    <mock:shadow-root>
         <dialog>
             <header>
                 <span id="title">
-                    <slot name="title"/>
+                    <span slot="title">Title</span>
                 </span>
                 <button tabindex="-1" id="close" title="Close">
                     <ion-icon name="close-outline"></ion-icon>
                 </button>
             </header>
-            <slot name="content"/>
+            <span slot="content">Content</span>
         </dialog>
-    </mock:shadow-root>
-    <span slot="title">
-        Title
-    </span>
-    <span slot="content">
-        Content
-    </span>
 </pos-dialog>
     `);
   });

--- a/elements/src/components/pos-dialog/test/pos-dialog.spec.tsx
+++ b/elements/src/components/pos-dialog/test/pos-dialog.spec.tsx
@@ -33,6 +33,36 @@ describe('pos-dialog', () => {
     `);
   });
 
+  it('showModal method calls showModal of the underlying dialog', async () => {
+    const page = await newSpecPage({
+      components: [PosDialog],
+      html: `<pos-dialog><span slot="dialog-title">Title</span><span slot="dialog-content">Content</span></pos-dialog>`,
+      supportsShadowDom: false,
+    });
+
+    const dialog = page.root.querySelector('dialog');
+    dialog.showModal = jest.fn();
+
+    page.rootInstance.showModal()
+
+    expect(dialog.showModal).toHaveBeenCalled();
+  });
+
+  it('close method closes the modal dialog', async () => {
+    const page = await newSpecPage({
+      components: [PosDialog],
+      html: `<pos-dialog><span slot="dialog-title">Title</span><span slot="dialog-content">Content</span></pos-dialog>`,
+      supportsShadowDom: false,
+    });
+
+    const dialog = page.root.querySelector('dialog');
+    dialog.close = jest.fn();
+
+    page.rootInstance.close()
+
+    expect(dialog.close).toHaveBeenCalled();
+  });
+
   it('closes the modal dialog, when the close button is clicked', async () => {
     const page = await newSpecPage({
       components: [PosDialog],

--- a/elements/src/components/pos-dialog/test/pos-dialog.spec.tsx
+++ b/elements/src/components/pos-dialog/test/pos-dialog.spec.tsx
@@ -6,7 +6,7 @@ describe('pos-dialog', () => {
   it('renders a dialog with the given slot content', async () => {
     const page = await newSpecPage({
       components: [PosDialog],
-      html: `<pos-dialog><span slot="dialog-title">Title</span><span slot="dialog-content">Content</span></pos-dialog>`,
+      html: `<pos-dialog><span slot="title">Title</span><span slot="content">Content</span></pos-dialog>`,
     });
     expect(page.root).toEqualHtml(`
 <pos-dialog>
@@ -14,19 +14,19 @@ describe('pos-dialog', () => {
         <dialog>
             <header>
                 <span id="title">
-                    <slot name="dialog-title"/>
+                    <slot name="title"/>
                 </span>
                 <button tabindex="-1" id="close" title="Close">
                     <ion-icon name="close-outline"></ion-icon>
                 </button>
             </header>
-            <slot name="dialog-content"/>
+            <slot name="content"/>
         </dialog>
     </mock:shadow-root>
-    <span slot="dialog-title">
+    <span slot="title">
         Title
     </span>
-    <span slot="dialog-content">
+    <span slot="content">
         Content
     </span>
 </pos-dialog>
@@ -36,7 +36,7 @@ describe('pos-dialog', () => {
   it('showModal method calls showModal of the underlying dialog', async () => {
     const page = await newSpecPage({
       components: [PosDialog],
-      html: `<pos-dialog><span slot="dialog-title">Title</span><span slot="dialog-content">Content</span></pos-dialog>`,
+      html: `<pos-dialog><span slot="title">Title</span><span slot="content">Content</span></pos-dialog>`,
       supportsShadowDom: false,
     });
 
@@ -51,7 +51,7 @@ describe('pos-dialog', () => {
   it('close method closes the modal dialog', async () => {
     const page = await newSpecPage({
       components: [PosDialog],
-      html: `<pos-dialog><span slot="dialog-title">Title</span><span slot="dialog-content">Content</span></pos-dialog>`,
+      html: `<pos-dialog><span slot="title">Title</span><span slot="content">Content</span></pos-dialog>`,
       supportsShadowDom: false,
     });
 
@@ -66,7 +66,7 @@ describe('pos-dialog', () => {
   it('closes the modal dialog, when the close button is clicked', async () => {
     const page = await newSpecPage({
       components: [PosDialog],
-      html: `<pos-dialog><span slot="dialog-title">Title</span><span slot="dialog-content">Content</span></pos-dialog>`,
+      html: `<pos-dialog><span slot="title">Title</span><span slot="content">Content</span></pos-dialog>`,
       supportsShadowDom: false,
     });
 

--- a/elements/src/components/pos-new-thing-form/pos-new-thing-form.tsx
+++ b/elements/src/components/pos-new-thing-form/pos-new-thing-form.tsx
@@ -46,6 +46,7 @@ export class PosNewThingForm implements PodOsAware {
           placeholder=""
           value={this.selectedTypeUri}
           onPod-os:term-selected={e => this.onTermSelected(e)}
+          autofocus
         />
         <label htmlFor="name">Name</label>
         <input id="name" type="text" value={this.name} onInput={e => this.handleChange(e)} />

--- a/elements/src/components/pos-select-term/pos-select-term.tsx
+++ b/elements/src/components/pos-select-term/pos-select-term.tsx
@@ -1,5 +1,5 @@
 import { PodOS } from '@pod-os/core';
-import { Term } from '@pod-os/core/types/terms';
+import { Term } from '@pod-os/core/src/terms';
 import { Component, Event, EventEmitter, h, Host, Prop, State, Watch } from '@stencil/core';
 import { PodOsAware, PodOsEventEmitter, subscribePodOs } from '../events/PodOsAware';
 
@@ -16,6 +16,8 @@ export class PosSelectTerm implements PodOsAware {
   @Prop() placeholder: string = 'Type to search...';
 
   @Prop() value: string = '';
+
+  @Prop() autofocus: boolean = false;
 
   @State() terms: Term[] = [];
 
@@ -52,6 +54,7 @@ export class PosSelectTerm implements PodOsAware {
           placeholder={this.placeholder}
           value={this.value}
           onChange={ev => this.handleChange(ev)}
+          autofocus={this.autofocus}
         ></input>
         <datalist part="terms" id="terms">
           {this.terms.map(term => (

--- a/storybook/stories/inputs/5_pos-dialog.stories.mdx
+++ b/storybook/stories/inputs/5_pos-dialog.stories.mdx
@@ -1,0 +1,30 @@
+import {html} from "lit-html";
+
+import {
+  Canvas,
+  Meta,
+  Story
+} from '@storybook/addon-docs/blocks';
+
+<Meta
+  title="Inputs"
+/>
+
+## pos-dialog
+
+Styled wrapper around native dialog element
+
+<Canvas
+  withSource="open">
+  <Story
+    name="pos-dialog"
+  >
+    {() => html`
+<button type="button" onClick="this.parentNode.querySelector('pos-dialog').showModal()">Click to open dialog</button>
+  <pos-dialog>
+      <span slot="dialog-title">Title</span>
+      <div slot="dialog-content">Content</div>
+  </pos-dialog>
+    `}
+  </Story>
+</Canvas>

--- a/storybook/stories/inputs/5_pos-dialog.stories.mdx
+++ b/storybook/stories/inputs/5_pos-dialog.stories.mdx
@@ -22,8 +22,8 @@ Styled wrapper around native dialog element
     {() => html`
 <button type="button" onClick="this.parentNode.querySelector('pos-dialog').showModal()">Click to open dialog</button>
   <pos-dialog>
-      <span slot="dialog-title">Title</span>
-      <div slot="dialog-content">Content</div>
+      <span slot="title">Title</span>
+      <div slot="content">Content</div>
   </pos-dialog>
     `}
   </Story>


### PR DESCRIPTION
Refactor to have dialog element with a common style

- [x] Create pos-dialog and use in pos-add-new-thing
- [x] Tests have been written
  - [x] all new code is covered by unit tests
    - [x] Change tests that the modal opens and closes for pos-add-new-thing
      - HTML now only shows `pos-dialog`
      - `pos-add-new-thing` unit test is no longer responsible for logic to close the dialog
    - [x] New unit test for `pos-dialog`
  - [x] the happy path of a new feature is covered by an end-to-end test
    - https://github.com/pod-os/PodOS/blob/main/apps/tests/add-new-thing.spec.ts still passes
  - [x] manual explorative tests have been performed
    - [x] Replicated existing behaviour of pos-add-new-thing
- [x] all dependencies are updated to the latest patch version at minimum
  - already done upstream
- [ ] the [CI pipeline](https://github.com/pod-os/PodOS/actions) passes
- [x] documentation is up-to-date
    - [x] TSDoc style comments on important functions, properties and events
    - [x] Readme.md files of PodOS elements have been re-generated
      - `npm run build` in elements
   - [x] stories for new PodOS elements have been added to [storybook](../../storybook)
     - [x] Add story to https://github.com/pod-os/PodOS/tree/main/storybook/stories/inputs      
  - [x] architectural decisions are documented as an [ADR](../decisions/0000-use-markdown-architectural-decision-records.md)
    - No new architectural decisions
  - [x] Changelogs are updated according to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
- [x] Fix formatting of second slot - pos-add-new-thing's CSS for pos-new-thing-form needs to be generalised
  - Used a drop in replacement using `::slotted`