### PR TITLE
doc(pos-list): add table example

### DIFF
--- a/elements/CHANGELOG.md
+++ b/elements/CHANGELOG.md
@@ -13,6 +13,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   - `pos-navigation` is now a more complex navigation widget, not just an input field.
   - It is planned to evolve into an Omnibox for searching and navigating in PodOS Browser.
 
+### Changes
+
+- [pos-list](../docs/elements/components/pos-list): Added storybook example using CSS grid and table aria roles
+
 ### Fixed
 
 - [pos-app-browser](../docs/elements/apps/pos-app-browser): prevent error message flashing up while uri is unset on hard refresh

--- a/storybook/stories/composition/2_list-composition.stories.mdx
+++ b/storybook/stories/composition/2_list-composition.stories.mdx
@@ -10,7 +10,8 @@ import { Canvas, Meta, Story } from "@storybook/addon-docs/blocks";
 ## pos-list composition
 
 This is an example of how you can use `<pos-list>` element to list things
-related to a resource with a custom display.
+related to a resource with a custom display. The `ul` and `li` elements are used
+as appropriate semantic HTML elements.
 
 <Canvas withSource="open">
   <Story name="pos-list composition">
@@ -31,6 +32,51 @@ Skills:
             </template>
         </pos-list>
     </ul>
+</pos-resource>
+    `}
+  </Story>
+</Canvas>
+
+## Table example
+
+The `table`-related HTML elements have strict rules that prevent other elements
+such as `pos-list` being used within them. Instead we can make a table using CSS
+`grid` rules. The grid needs to be defined within each template as `pos-list`
+nests list items within `pos-resource` elements, which use shadow dom.
+
+<Canvas withSource="open">
+  <Story name="pos-list table">
+    {({ uri }) => html`
+<style>
+    [role="row"] {
+        display: grid;
+        grid-template-columns: 200px 600px;
+    }
+    .header {
+        font-weight: bold;
+    }
+    [role="gridcell"], [role="columnheader"] {
+        border: 1px solid grey;
+    }
+</style>
+<pos-resource uri=${uri} role="grid" aria-labelledby="skills-caption">
+    <span role="caption" id="skills-caption">Table of skills</span>
+    <div role="row" class="header">
+        <div role="columnheader">Skill</div>
+        <div role="columnheader">URL</div>
+    </div>
+    <pos-list rel="http://schema.org/skills">
+        <template>
+            <div role="row">
+                <pos-list rel="http://www.w3.org/ns/solid/terms#publicId" role="gridcell">
+                    <template>
+                        <pos-label></pos-label>
+                    </template>
+                </pos-list>
+                <pos-value predicate="http://www.w3.org/ns/solid/terms#publicId" role="gridcell" /></pos-value>
+            <div>
+        </template>
+    </pos-list>
 </pos-resource>
     `}
   </Story>

--- a/storybook/stories/composition/2_list-composition.stories.mdx
+++ b/storybook/stories/composition/2_list-composition.stories.mdx
@@ -55,11 +55,11 @@ nests list items within `pos-resource` elements, which use shadow dom.
     .header {
         font-weight: bold;
     }
-    [role="gridcell"], [role="columnheader"] {
+    [role="cell"], [role="columnheader"] {
         border: 1px solid grey;
     }
 </style>
-<pos-resource uri=${uri} role="grid" aria-labelledby="skills-caption">
+<pos-resource uri=${uri} role="table" aria-labelledby="skills-caption">
     <span role="caption" id="skills-caption">Table of skills</span>
     <div role="row" class="header">
         <div role="columnheader">Skill</div>
@@ -68,12 +68,12 @@ nests list items within `pos-resource` elements, which use shadow dom.
     <pos-list rel="http://schema.org/skills">
         <template>
             <div role="row">
-                <pos-list rel="http://www.w3.org/ns/solid/terms#publicId" role="gridcell">
+                <pos-list rel="http://www.w3.org/ns/solid/terms#publicId" role="cell">
                     <template>
                         <pos-label></pos-label>
                     </template>
                 </pos-list>
-                <pos-value predicate="http://www.w3.org/ns/solid/terms#publicId" role="gridcell" /></pos-value>
+                <pos-value predicate="http://www.w3.org/ns/solid/terms#publicId" role="cell" /></pos-value>
             <div>
         </template>
     </pos-list>


### PR DESCRIPTION
Candidate to address #134 

This adds a storybook example that shows how pos-list can be used to create a table, given that `table` elements cannot be used, and in absence of a more suited custom component.

I do consider this to require a dashboard creator to be fairly comfortable with HTML and CSS - there's a lot of boilerplate - but I also think it's intuitive enough that someone could copy paste the example and adjust it.

I've added it as a second example in list composition because it's the exact same thing, just styled differently. I'm not sure if that's appropriate.

I've tried to get the aria roles right.

![image](https://github.com/user-attachments/assets/c8313a3a-6bc0-4107-9411-09317fcbfaca)


- [x] Tests have been written
  - Example could be affected by future changes to `pos-list` but this would anyway trigger changes to the storybook. In principle new accessibility tests could be written but this currently relies on browser functionality rather than provided by `pos-list`
  - [x] N/A. all new code is covered by unit tests
  - [x] N/A. the happy path of a new feature is covered by an end-to-end test
  - [x] manual explorative tests have been performed
- [ ] all dependencies are updated to the latest patch version at minimum
- [x] N/A. the [CI pipeline](https://github.com/pod-os/PodOS/actions) passes - no change
- [x] documentation is up-to-date
    - [x] N/A. TSDoc style comments on important functions, properties and events
    - [x] stories for new PodOS elements have been added to [storybook](../../storybook)
  - [x] N/A. Readme.md files of PodOS elements have been re-generated
  - [x] N/A. architectural decisions are documented as an [ADR](../decisions/0000-use-markdown-architectural-decision-records.md)
  - [x] Changelogs are updated according to
        [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)