### PR TITLE
feat(pos-rich-link): can use custom content

### DIFF
--- a/elements/CHANGELOG.md
+++ b/elements/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [pos-rich-link](../docs/elements/components/pos-rich-link):
   - can now receive a resource to use for the link
   - can now follow `rel` and `rev` to discover a resource to use for the link
+  - can use custom content by providing it in an unnamed slot
 - [pos-login-form](../docs/elements/components/pos-login-form):
   - update the list of Identity Providers (IdPs) to contain trailing slashes where needed
   - removed IdPs that are outdated or do not work anymore with the new auth lib

--- a/elements/src/components/pos-rich-link/pos-rich-link.integration.spec.tsx
+++ b/elements/src/components/pos-rich-link/pos-rich-link.integration.spec.tsx
@@ -154,4 +154,33 @@ describe('pos-rich-link', () => {
       </pos-rich-link>
   `);
   });
+
+  it('renders slotted label with received resource ', async () => {
+    const page = await newSpecPage({
+      components: [PosApp, PosLabel, PosResource, PosRichLink],
+      html: `
+        <pos-app>
+          <pos-resource uri='https://resource.test'>
+            <pos-rich-link>
+              <pos-label/>
+            </pos-rich-link>
+          </pos-resource>
+        </pos-app>
+          `,
+      supportsShadowDom: false,
+    });
+
+    expect(os.store.get.mock.calls).toHaveLength(1);
+
+    const link = page.root?.querySelector('pos-rich-link');
+    expect(link).toEqualHtml(`
+      <pos-rich-link>
+        <a href="https://resource.test">
+          <pos-label>
+            Test label
+          </pos-label>
+        </a>
+      </pos-rich-link>
+  `);
+  });
 });

--- a/elements/src/components/pos-rich-link/pos-rich-link.spec.tsx
+++ b/elements/src/components/pos-rich-link/pos-rich-link.spec.tsx
@@ -192,9 +192,8 @@ describe('pos-rich-link with slot', () => {
       html: `<pos-rich-link uri="https://pod.example/resource">Link text</pos-rich-link>`,
       supportsShadowDom: false,
     });
-    expect(page?.root?.innerHTML).toEqualHtml(
+    expect(page.root.firstElementChild).toEqualHtml(
       `
-      <!---->
       <pos-resource lazy="" uri="https://pod.example/resource">
         <a href="https://pod.example/resource">
           Link text
@@ -210,9 +209,8 @@ describe('pos-rich-link with slot', () => {
       html: `<pos-rich-link uri="https://pod.example/resource"><pos-label/></pos-rich-link>`,
       supportsShadowDom: false,
     });
-    expect(page?.root?.innerHTML).toEqualHtml(
+    expect(page.root.firstElementChild).toEqualHtml(
       `
-      <!---->
       <pos-resource lazy="" uri="https://pod.example/resource">
         <a href="https://pod.example/resource">
           <pos-label/>
@@ -232,8 +230,7 @@ describe('pos-rich-link with slot', () => {
       uri: 'https://pod.example/resource',
     });
     await page.waitForChanges();
-    expect(page?.root?.innerHTML).toEqualHtml(`
-      <!---->
+    expect(page.root.firstElementChild).toEqualHtml(`
       <a href="https://pod.example/resource">
         Link text
       </a>`);
@@ -249,8 +246,7 @@ describe('pos-rich-link with slot', () => {
       uri: 'https://pod.example/resource',
     });
     await page.waitForChanges();
-    expect(page?.root?.innerHTML).toEqualHtml(`
-      <!---->
+    expect(page.root.firstElementChild).toEqualHtml(`
       <a href="https://pod.example/resource">
         <pos-label/>
       </a>`);

--- a/elements/src/components/pos-rich-link/pos-rich-link.spec.tsx
+++ b/elements/src/components/pos-rich-link/pos-rich-link.spec.tsx
@@ -184,3 +184,75 @@ describe('pos-rich-link without uri', () => {
     );
   });
 });
+
+describe('pos-rich-link with slot', () => {
+  it('uses slotted text if present with specified uri', async () => {
+    const page = await newSpecPage({
+      components: [PosRichLink],
+      html: `<pos-rich-link uri="https://pod.example/resource">Link text</pos-rich-link>`,
+      supportsShadowDom: false,
+    });
+    expect(page?.root?.innerHTML).toEqualHtml(
+      `
+      <!---->
+      <pos-resource lazy="" uri="https://pod.example/resource">
+        <a href="https://pod.example/resource">
+          Link text
+        </a>
+      </pos-resource>
+      `,
+    );
+  });
+
+  it('uses slotted element if present with specified uri', async () => {
+    const page = await newSpecPage({
+      components: [PosRichLink],
+      html: `<pos-rich-link uri="https://pod.example/resource"><pos-label/></pos-rich-link>`,
+      supportsShadowDom: false,
+    });
+    expect(page?.root?.innerHTML).toEqualHtml(
+      `
+      <!---->
+      <pos-resource lazy="" uri="https://pod.example/resource">
+        <a href="https://pod.example/resource">
+          <pos-label/>
+        </a>
+      </pos-resource>
+      `,
+    );
+  });
+
+  it('uses slotted text if present with received resource ', async () => {
+    const page = await newSpecPage({
+      components: [PosRichLink],
+      html: `<pos-rich-link>Link text</pos-rich-link>`,
+      supportsShadowDom: false,
+    });
+    await page.rootInstance.receiveResource({
+      uri: 'https://pod.example/resource',
+    });
+    await page.waitForChanges();
+    expect(page?.root?.innerHTML).toEqualHtml(`
+      <!---->
+      <a href="https://pod.example/resource">
+        Link text
+      </a>`);
+  });
+
+  it('uses slotted element if present with received resource ', async () => {
+    const page = await newSpecPage({
+      components: [PosRichLink],
+      html: `<pos-rich-link><pos-label/></pos-rich-link>`,
+      supportsShadowDom: false,
+    });
+    await page.rootInstance.receiveResource({
+      uri: 'https://pod.example/resource',
+    });
+    await page.waitForChanges();
+    expect(page?.root?.innerHTML).toEqualHtml(`
+      <!---->
+      <a href="https://pod.example/resource">
+        <pos-label/>
+      </a>`);
+  });
+});

--- a/elements/src/components/pos-rich-link/pos-rich-link.tsx
+++ b/elements/src/components/pos-rich-link/pos-rich-link.tsx
@@ -1,5 +1,5 @@
 import { Relation, Thing } from '@pod-os/core';
-import { Component, Event, EventEmitter, h, Prop, State } from '@stencil/core';
+import { Component, Element, Event, EventEmitter, h, Prop, State } from '@stencil/core';
 import { ResourceAware, ResourceEventEmitter, subscribeResource } from '../events/ResourceAware';
 
 @Component({
@@ -32,7 +32,13 @@ export class PosRichLink implements ResourceAware {
   @State() followPredicate: boolean = false;
   @State() error: string = null;
 
+  @Element() host: HTMLElement;
+
+  @State()
+  private customContent: boolean = false;
+
   componentWillLoad() {
+    this.customContent = !!this.host.lastElementChild || this.host.textContent.trim() != '';
     if (!this.uri) subscribeResource(this);
   }
 
@@ -64,8 +70,8 @@ export class PosRichLink implements ResourceAware {
   };
 
   render() {
-    const content = (uri: string) => (
-      <p class="content">
+    const content = (uri: string) =>
+      this.customContent ? (
         <a
           href={uri}
           onClick={e => {
@@ -73,12 +79,23 @@ export class PosRichLink implements ResourceAware {
             this.linkEmitter.emit(uri);
           }}
         >
-          <pos-label />
+          <slot></slot>
         </a>
-        <span class="url">{new URL(uri).host}</span>
-        <pos-description />
-      </p>
-    );
+      ) : (
+        <p class="content">
+          <a
+            href={uri}
+            onClick={e => {
+              e.preventDefault();
+              this.linkEmitter.emit(uri);
+            }}
+          >
+            <pos-label />
+          </a>
+          <span class="url">{new URL(uri).host}</span>
+          <pos-description />
+        </p>
+      );
 
     if (this.error) {
       return this.error;

--- a/elements/src/components/pos-rich-link/pos-rich-link.tsx
+++ b/elements/src/components/pos-rich-link/pos-rich-link.tsx
@@ -35,10 +35,12 @@ export class PosRichLink implements ResourceAware {
   @Element() host: HTMLElement;
 
   @State()
-  private customContent: boolean = false;
+  private showCustomContent: boolean = false;
 
   componentWillLoad() {
-    this.customContent = !!this.host.lastElementChild || this.host.textContent.trim() != '';
+    this.showCustomContent = // custom content can either be given as child elements, or as just text, so we check for both:
+      !!this.host.lastElementChild || // either has any child element
+      this.host.textContent.trim() != ''; // or contains a non-empty text
     if (!this.uri) subscribeResource(this);
   }
 
@@ -71,7 +73,7 @@ export class PosRichLink implements ResourceAware {
 
   render() {
     const content = (uri: string) =>
-      this.customContent ? (
+      this.showCustomContent ? (
         <a
           href={uri}
           onClick={e => {

--- a/storybook/stories/composition/1_resource-composition.stories.mdx
+++ b/storybook/stories/composition/1_resource-composition.stories.mdx
@@ -29,7 +29,7 @@ This is an example of how you can combine a `<pos-resource>` element with any ht
         <div><pos-description /></div>
     </blockquote>
     <div>
-      <h2>Here is a table with some facts about <span><pos-label /></span>:</h2>
+      <h2>Here is a table with some facts about <pos-rich-link><pos-label /></pos-rich-link>:</h2>
       <pos-literals />
     </div>
 </pos-resource>

--- a/storybook/stories/navigation/0_pos-rich-link.stories.mdx
+++ b/storybook/stories/navigation/0_pos-rich-link.stories.mdx
@@ -23,6 +23,14 @@ identified by that URI, if available.
   </Story>
 </Canvas>
 
+The text to be displayed to the user can be overridden
+
+<Canvas withSource="open">
+  <Story name="pos-rich-link with custom content">
+    {({ uri }) => html` <pos-rich-link uri=${uri}>Link text</pos-rich-link> `}
+  </Story>
+</Canvas>
+
 Link can be obtained by receiving a resource from an ancestor element
 
 <Canvas withSource="open">


### PR DESCRIPTION
Closes #131 implemented using a single unnamed slot

- [x] Tests have been written
  - [x] all new code is covered by unit tests
  - [x] the happy path of a new feature is covered by an end-to-end test
    - integration test combining pos-app, pos-resource, pos-rich-link and pos-label
  - [x] manual explorative tests have been performed
- [x] N/A - all dependencies are updated to the latest patch version at minimum
- [x] the [CI pipeline](https://github.com/pod-os/PodOS/actions) passes
- [x] documentation is up-to-date
    - [x] N/A - TSDoc style comments on important functions, properties and events
    - [x] stories for new PodOS elements have been added to [storybook](../../storybook)
  - [x] Readme.md files of PodOS elements have been re-generated
  - [x] N/A - architectural decisions are documented as an [ADR](../decisions/0000-use-markdown-architectural-decision-records.md)
  - [x] Changelogs are updated according to
        [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)