### PR TITLE
HTML Tool PoC spike for fragment defined in type index

### DIFF
--- a/docs/elements/components/pos-html-tool/readme.md
+++ b/docs/elements/components/pos-html-tool/readme.md
@@ -1,0 +1,14 @@
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property   | Attribute  | Description                          | Type     | Default     |
+| ---------- | ---------- | ------------------------------------ | -------- | ----------- |
+| `fragment` | `fragment` | HTML fragment to sanitize and render | `string` | `undefined` |
+
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/docs/elements/components/pos-html-tool/readme.md
+++ b/docs/elements/components/pos-html-tool/readme.md
@@ -1,0 +1,15 @@
+# pos-html-tool
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property   | Attribute  | Description                          | Type     | Default     |
+| ---------- | ---------- | ------------------------------------ | -------- | ----------- |
+| `fragment` | `fragment` | HTML fragment to sanitize and render | `string` | `undefined` |
+
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/elements/package.json
+++ b/elements/package.json
@@ -33,6 +33,7 @@
     "@tiptap/pm": "^3.10.1",
     "@tiptap/starter-kit": "^3.10.1",
     "@uvdsl/solid-oidc-client-browser": "^0.1.3",
+    "dompurify": "^3.3.0",
     "idb": "^8.0.3",
     "neverthrow": "^8.2.0",
     "pollen-css": "^5.0.2",

--- a/elements/package.json
+++ b/elements/package.json
@@ -38,6 +38,7 @@
     "@uppy/image-editor": "^4.2.0",
     "@uppy/webcam": "^5.1.0",
     "@uvdsl/solid-oidc-client-browser": "^0.1.3",
+    "dompurify": "^3.3.0",
     "idb": "^8.0.3",
     "neverthrow": "^8.2.0",
     "pollen-css": "^5.0.2",

--- a/elements/src/components.d.ts
+++ b/elements/src/components.d.ts
@@ -66,6 +66,12 @@ export namespace Components {
     }
     interface PosGettingStarted {
     }
+    interface PosHtmlTool {
+        /**
+          * HTML fragment to sanitize and render
+         */
+        "fragment": string;
+    }
     /**
      * Tries fetch an image with the solid authentication, and can visualize http errors like 403 or 404 if this fails.
      * Falls back to classic `<img src="...">` on network errors like CORS.
@@ -625,6 +631,12 @@ declare global {
         prototype: HTMLPosGettingStartedElement;
         new (): HTMLPosGettingStartedElement;
     };
+    interface HTMLPosHtmlToolElement extends Components.PosHtmlTool, HTMLStencilElement {
+    }
+    var HTMLPosHtmlToolElement: {
+        prototype: HTMLPosHtmlToolElement;
+        new (): HTMLPosHtmlToolElement;
+    };
     interface HTMLPosImageElementEventMap {
         "pod-os:init": any;
         "pod-os:resource-loaded": string;
@@ -1113,6 +1125,7 @@ declare global {
         "pos-error-toast": HTMLPosErrorToastElement;
         "pos-example-resources": HTMLPosExampleResourcesElement;
         "pos-getting-started": HTMLPosGettingStartedElement;
+        "pos-html-tool": HTMLPosHtmlToolElement;
         "pos-image": HTMLPosImageElement;
         "pos-internal-router": HTMLPosInternalRouterElement;
         "pos-label": HTMLPosLabelElement;
@@ -1237,6 +1250,12 @@ declare namespace LocalJSX {
     }
     interface PosGettingStarted {
         "onPod-os:login"?: (event: PosGettingStartedCustomEvent<void>) => void;
+    }
+    interface PosHtmlTool {
+        /**
+          * HTML fragment to sanitize and render
+         */
+        "fragment"?: string;
     }
     /**
      * Tries fetch an image with the solid authentication, and can visualize http errors like 403 or 404 if this fails.
@@ -1476,6 +1495,7 @@ declare namespace LocalJSX {
         "pos-error-toast": PosErrorToast;
         "pos-example-resources": PosExampleResources;
         "pos-getting-started": PosGettingStarted;
+        "pos-html-tool": PosHtmlTool;
         "pos-image": PosImage;
         "pos-internal-router": PosInternalRouter;
         "pos-label": PosLabel;
@@ -1533,6 +1553,7 @@ declare module "@stencil/core" {
             "pos-error-toast": LocalJSX.PosErrorToast & JSXBase.HTMLAttributes<HTMLPosErrorToastElement>;
             "pos-example-resources": LocalJSX.PosExampleResources & JSXBase.HTMLAttributes<HTMLPosExampleResourcesElement>;
             "pos-getting-started": LocalJSX.PosGettingStarted & JSXBase.HTMLAttributes<HTMLPosGettingStartedElement>;
+            "pos-html-tool": LocalJSX.PosHtmlTool & JSXBase.HTMLAttributes<HTMLPosHtmlToolElement>;
             /**
              * Tries fetch an image with the solid authentication, and can visualize http errors like 403 or 404 if this fails.
              * Falls back to classic `<img src="...">` on network errors like CORS.

--- a/elements/src/components.d.ts
+++ b/elements/src/components.d.ts
@@ -122,6 +122,12 @@ export namespace Components {
     }
     interface PosGettingStarted {
     }
+    interface PosHtmlTool {
+        /**
+          * HTML fragment to sanitize and render
+         */
+        "fragment": string;
+    }
     /**
      * Tries fetch an image with the solid authentication, and can visualize http errors like 403 or 404 if this fails.
      * Falls back to classic `<img src="...">` on network errors like CORS.
@@ -830,6 +836,12 @@ declare global {
         prototype: HTMLPosGettingStartedElement;
         new (): HTMLPosGettingStartedElement;
     };
+    interface HTMLPosHtmlToolElement extends Components.PosHtmlTool, HTMLStencilElement {
+    }
+    var HTMLPosHtmlToolElement: {
+        prototype: HTMLPosHtmlToolElement;
+        new (): HTMLPosHtmlToolElement;
+    };
     interface HTMLPosImageElementEventMap {
         "pod-os:init": any;
         "pod-os:resource-loaded": string;
@@ -1394,6 +1406,7 @@ declare global {
         "pos-error-toast": HTMLPosErrorToastElement;
         "pos-example-resources": HTMLPosExampleResourcesElement;
         "pos-getting-started": HTMLPosGettingStartedElement;
+        "pos-html-tool": HTMLPosHtmlToolElement;
         "pos-image": HTMLPosImageElement;
         "pos-internal-router": HTMLPosInternalRouterElement;
         "pos-label": HTMLPosLabelElement;
@@ -1582,6 +1595,12 @@ declare namespace LocalJSX {
     }
     interface PosGettingStarted {
         "onPod-os:login"?: (event: PosGettingStartedCustomEvent<void>) => void;
+    }
+    interface PosHtmlTool {
+        /**
+          * HTML fragment to sanitize and render
+         */
+        "fragment"?: string;
     }
     /**
      * Tries fetch an image with the solid authentication, and can visualize http errors like 403 or 404 if this fails.
@@ -1998,6 +2017,7 @@ declare namespace LocalJSX {
         "pos-error-toast": PosErrorToast;
         "pos-example-resources": PosExampleResources;
         "pos-getting-started": PosGettingStarted;
+        "pos-html-tool": PosHtmlTool;
         "pos-image": Omit<PosImage, keyof PosImageAttributes> & { [K in keyof PosImage & keyof PosImageAttributes]?: PosImage[K] } & { [K in keyof PosImage & keyof PosImageAttributes as `attr:${K}`]?: PosImageAttributes[K] } & { [K in keyof PosImage & keyof PosImageAttributes as `prop:${K}`]?: PosImage[K] };
         "pos-internal-router": Omit<PosInternalRouter, keyof PosInternalRouterAttributes> & { [K in keyof PosInternalRouter & keyof PosInternalRouterAttributes]?: PosInternalRouter[K] } & { [K in keyof PosInternalRouter & keyof PosInternalRouterAttributes as `attr:${K}`]?: PosInternalRouterAttributes[K] } & { [K in keyof PosInternalRouter & keyof PosInternalRouterAttributes as `prop:${K}`]?: PosInternalRouter[K] };
         "pos-label": PosLabel;
@@ -2077,6 +2097,7 @@ declare module "@stencil/core" {
             "pos-error-toast": LocalJSX.IntrinsicElements["pos-error-toast"] & JSXBase.HTMLAttributes<HTMLPosErrorToastElement>;
             "pos-example-resources": LocalJSX.IntrinsicElements["pos-example-resources"] & JSXBase.HTMLAttributes<HTMLPosExampleResourcesElement>;
             "pos-getting-started": LocalJSX.IntrinsicElements["pos-getting-started"] & JSXBase.HTMLAttributes<HTMLPosGettingStartedElement>;
+            "pos-html-tool": LocalJSX.PosHtmlTool & JSXBase.HTMLAttributes<HTMLPosHtmlToolElement>;
             /**
              * Tries fetch an image with the solid authentication, and can visualize http errors like 403 or 404 if this fails.
              * Falls back to classic `<img src="...">` on network errors like CORS.

--- a/elements/src/components/pos-html-tool/pos-html-tool.integration.spec.tsx
+++ b/elements/src/components/pos-html-tool/pos-html-tool.integration.spec.tsx
@@ -1,0 +1,38 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { mockPodOS } from '../../test/mockPodOS';
+import { PosHtmlTool } from './pos-html-tool';
+import { PosApp } from '../pos-app/pos-app';
+import { PosLabel } from '../pos-label/pos-label';
+import { PosResource } from '../pos-resource/pos-resource';
+import { Thing } from '@pod-os/core';
+import { when } from 'jest-when';
+
+describe('pos-html-tool', () => {
+  it('respects the resource event and renders inserted pos-label', async () => {
+    const os = mockPodOS();
+    when(os.store.get)
+      .calledWith('https://resource.test')
+      .mockReturnValue({
+        label: () => 'Test Resource',
+      } as unknown as Thing);
+    const page = await newSpecPage({
+      components: [PosApp, PosResource, PosLabel, PosHtmlTool],
+      html: `<pos-app>
+            <pos-resource uri="https://resource.test" lazy="true">
+              <pos-html-tool/>
+            </pos-resource>
+        </pos-app>`,
+    });
+    const el = page.root?.querySelector('pos-html-tool') as unknown as PosHtmlTool;
+    el.fragment = '<pos-label></pos-label>';
+    await page.waitForChanges();
+    const label = page.root?.querySelector('pos-label');
+    expect(label).toEqualHtml(`
+      <pos-label>
+        <mock:shadow-root>
+          Test Resource
+        </mock:shadow-root>
+      </pos-label>
+  `);
+  });
+});

--- a/elements/src/components/pos-html-tool/pos-html-tool.spec.tsx
+++ b/elements/src/components/pos-html-tool/pos-html-tool.spec.tsx
@@ -1,0 +1,20 @@
+/**
+ * @jest-environment @happy-dom/jest-environment
+ *
+ * => dompurify needs a real DOM to work
+ */
+
+import { newSpecPage } from '@stencil/core/testing';
+import { PosHtmlTool } from './pos-html-tool';
+
+describe('pos-html-tool', () => {
+  it('inserts sanitized HTML into the page', async () => {
+    const page = await newSpecPage({
+      components: [PosHtmlTool],
+      html: `<pos-html-tool/>`,
+    });
+    page.rootInstance.fragment = '<pos-label></pos-label>';
+    await page.waitForChanges();
+    expect(page.root?.innerHTML).toEqualHtml('<pos-label></pos-label>');
+  });
+});

--- a/elements/src/components/pos-html-tool/pos-html-tool.tsx
+++ b/elements/src/components/pos-html-tool/pos-html-tool.tsx
@@ -1,0 +1,17 @@
+import { Component, h, Host, Prop } from '@stencil/core';
+import { sanitizeHtmlTool } from './sanitizeHtmlTool';
+
+@Component({
+  tag: 'pos-html-tool',
+  shadow: true,
+})
+export class PosHtmlTool {
+  /**
+   * HTML fragment to sanitize and render
+   */
+  @Prop() fragment: string;
+
+  render() {
+    return <Host innerHTML={sanitizeHtmlTool(this.fragment)}></Host>;
+  }
+}

--- a/elements/src/components/pos-html-tool/pos-html-tool.tsx
+++ b/elements/src/components/pos-html-tool/pos-html-tool.tsx
@@ -3,7 +3,7 @@ import { sanitizeHtmlTool } from './sanitizeHtmlTool';
 
 @Component({
   tag: 'pos-html-tool',
-  shadow: true,
+  shadow: false,
 })
 export class PosHtmlTool {
   /**

--- a/elements/src/components/pos-html-tool/sanitizeHtmlTool.spec.tsx
+++ b/elements/src/components/pos-html-tool/sanitizeHtmlTool.spec.tsx
@@ -1,0 +1,19 @@
+/**
+ * @jest-environment @happy-dom/jest-environment
+ *
+ * => dompurify needs a real DOM to work
+ */
+
+import { sanitizeHtmlTool } from './sanitizeHtmlTool';
+
+describe('sanitizeHtmlTool', () => {
+  it('keeps whitelisted elements', () => {
+    const sanitized = sanitizeHtmlTool('<pos-label></pos-label>');
+    expect(sanitized).toEqual('<pos-label></pos-label>');
+  });
+
+  it('removes unknown HTML elements from fragment', () => {
+    const sanitized = sanitizeHtmlTool('<unknown-element>');
+    expect(sanitized).toEqual('');
+  });
+});

--- a/elements/src/components/pos-html-tool/sanitizeHtmlTool.tsx
+++ b/elements/src/components/pos-html-tool/sanitizeHtmlTool.tsx
@@ -1,0 +1,5 @@
+import DOMPurify from 'dompurify';
+
+export function sanitizeHtmlTool(htmlToolFragment: string) {
+  return DOMPurify.sanitize(htmlToolFragment, { ADD_TAGS: ['pos-label'] });
+}

--- a/elements/src/components/pos-label/pos-label.sanitizeHtmlTool.spec.tsx
+++ b/elements/src/components/pos-label/pos-label.sanitizeHtmlTool.spec.tsx
@@ -1,0 +1,13 @@
+/**
+ * @jest-environment @happy-dom/jest-environment
+ *
+ * => dompurify needs a real DOM to work
+ */
+import { sanitizeHtmlTool } from '../pos-html-tool/sanitizeHtmlTool';
+
+describe('pos-label', () => {
+  it('is whitelisted by sanitizeHtmlTool', () => {
+    const sanitized = sanitizeHtmlTool('<pos-label/>');
+    expect(sanitized).toEqual('<pos-label></pos-label>');
+  });
+});

--- a/elements/src/components/pos-type-router/pos-type-router.spec.tsx
+++ b/elements/src/components/pos-type-router/pos-type-router.spec.tsx
@@ -136,6 +136,29 @@ describe('pos-type-router', () => {
 `);
   });
 
+  it('renders HTML tool if available', async () => {
+    const page = await newSpecPage({
+      components: [PosTypeRouter],
+      html: `<pos-type-router />`,
+      supportsShadowDom: false,
+    });
+    await page.rootInstance.receiveResource({
+      types: () => [{ uri: 'https://schema.org/Recipe', label: 'Recipe' }],
+    });
+    await page.waitForChanges();
+
+    expect(page.root).toEqualHtml(`
+    <pos-type-router>
+      <section>
+        <pos-tool-select></pos-tool-select>
+        <div class="tools">
+          <pos-html-tool class="tool visible" fragment="<pos-label/>"></pos-html-tool>
+        </div>
+      </section>
+    </pos-type-router>
+`);
+  });
+
   it('renders the selected tool and updates query param', async () => {
     const page = await newSpecPage({
       components: [PosTypeRouter],

--- a/elements/src/components/pos-type-router/pos-type-router.tsx
+++ b/elements/src/components/pos-type-router/pos-type-router.tsx
@@ -1,7 +1,7 @@
 import { Thing } from '@pod-os/core';
 import { Component, Event, EventEmitter, h, Listen, State } from '@stencil/core';
 import { ResourceAware, subscribeResource } from '../events/ResourceAware';
-import { selectToolsForTypes, ToolConfig } from './selectToolsForTypes';
+import { HTMLToolConfig, selectToolsForTypes, ToolConfig } from './selectToolsForTypes';
 
 /**
  * This component is responsible for rendering tools that are useful to interact with the current resource.
@@ -43,7 +43,21 @@ export class PosTypeRouter implements ResourceAware {
 
   receiveResource = (resource: Thing) => {
     const types = resource.types();
-    this.availableTools = selectToolsForTypes(types);
+    const registeredTools = [
+      {
+        element: 'pos-html-tool',
+        label: 'Example tool',
+        icon: 'list-ul',
+        types: [
+          {
+            uri: 'https://schema.org/Recipe',
+            priority: 20,
+          },
+        ],
+        fragment: '<pos-label/>',
+      },
+    ];
+    this.availableTools = selectToolsForTypes(types, registeredTools);
     this.currentTool = this.availableTools.find(it => it.element === this.initialTool) ?? this.availableTools[0];
   };
 
@@ -59,7 +73,14 @@ export class PosTypeRouter implements ResourceAware {
         <pos-tool-select selected={this.currentTool} tools={this.availableTools}></pos-tool-select>
         <div class={{ tools: true, transition: this.transitioning }} onAnimationEnd={() => this.removeOldTool()}>
           {OldTool && <OldTool class="tool hidden"></OldTool>}
-          <SelectedTool class="tool visible"></SelectedTool>
+          {SelectedTool == 'pos-html-tool' ? (
+            <pos-html-tool
+              fragment={(this.currentTool as HTMLToolConfig).fragment}
+              class="tool visible"
+            ></pos-html-tool>
+          ) : (
+            <SelectedTool class="tool visible"></SelectedTool>
+          )}
         </div>
       </section>
     );

--- a/elements/src/components/pos-type-router/selectToolsForTypes.spec.ts
+++ b/elements/src/components/pos-type-router/selectToolsForTypes.spec.ts
@@ -97,4 +97,23 @@ describe('select tools for types', () => {
       AvailableTools.Generic,
     ]);
   });
+
+  it('favours HTML tool over generic if one is available', () => {
+    const registeredTools = [
+      {
+        element: 'pos-html-tool',
+        label: 'Example tool',
+        icon: 'list-ul',
+        types: [
+          {
+            uri: 'https://schema.org/Recipe',
+            priority: 20,
+          },
+        ],
+      },
+    ];
+    const types = [{ uri: 'https://schema.org/Recipe', label: 'Recipe' }];
+    const tools = selectToolsForTypes(types, registeredTools);
+    expect(tools).toEqual([registeredTools[0], AvailableTools.Generic]);
+  });
 });

--- a/elements/src/components/pos-type-router/selectToolsForTypes.spec.ts
+++ b/elements/src/components/pos-type-router/selectToolsForTypes.spec.ts
@@ -113,4 +113,23 @@ describe('select tools for types', () => {
       AvailableTools.Attachments,
     ]);
   });
+
+  it('favours HTML tool over generic if one is available', () => {
+    const registeredTools = [
+      {
+        element: 'pos-html-tool',
+        label: 'Example tool',
+        icon: 'list-ul',
+        types: [
+          {
+            uri: 'https://schema.org/Recipe',
+            priority: 20,
+          },
+        ],
+      },
+    ];
+    const types = [{ uri: 'https://schema.org/Recipe', label: 'Recipe' }];
+    const tools = selectToolsForTypes(types, registeredTools);
+    expect(tools).toEqual([registeredTools[0], AvailableTools.Generic]);
+  });
 });

--- a/elements/src/components/pos-type-router/selectToolsForTypes.ts
+++ b/elements/src/components/pos-type-router/selectToolsForTypes.ts
@@ -25,6 +25,13 @@ export interface ToolConfig {
 }
 
 /**
+ * Describes a tool that can be used implemented as a HTML fragment
+ */
+export interface HTMLToolConfig extends ToolConfig {
+  fragment: string;
+}
+
+/**
  * Describes how well a given RDF type can be handled
  */
 interface TypePriority {
@@ -52,10 +59,10 @@ interface ToolPriority {
   priority: number;
 }
 
-export function selectToolsForTypes(types: RdfType[]) {
+export function selectToolsForTypes(types: RdfType[], registeredTools: ToolConfig[] = []) {
   const typeUris = new Set(types.map(type => type.uri));
 
-  return Object.values(AvailableTools)
+  return [...Object.values(AvailableTools), ...registeredTools]
     .map(maxPriorityFor(typeUris))
     .filter(onlyRelevant)
     .toSorted(byPriority)

--- a/package-lock.json
+++ b/package-lock.json
@@ -113,6 +113,9 @@
         "typedoc-plugin-markdown": "^4.9.0",
         "typescript": "5.9.3",
         "typescript-eslint": "^8.46.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "core/node_modules/@jest/console": {
@@ -1303,6 +1306,7 @@
         "@tiptap/pm": "^3.10.1",
         "@tiptap/starter-kit": "^3.10.1",
         "@uvdsl/solid-oidc-client-browser": "^0.1.3",
+        "dompurify": "^3.3.0",
         "idb": "^8.0.3",
         "neverthrow": "^8.2.0",
         "pollen-css": "^5.0.2",
@@ -10982,6 +10986,15 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.0.tgz",
+      "integrity": "sha512-r+f6MYR1gGN1eJv0TVQbhA7if/U7P87cdPl3HN5rikqaBSBxLiCb/b9O+2eG0cxz0ghyU+mU1QkbsOwERMYlWQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/domutils": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1467,6 +1467,7 @@
         "@uppy/image-editor": "^4.2.0",
         "@uppy/webcam": "^5.1.0",
         "@uvdsl/solid-oidc-client-browser": "^0.1.3",
+        "dompurify": "^3.3.0",
         "idb": "^8.0.3",
         "neverthrow": "^8.2.0",
         "pollen-css": "^5.0.2",
@@ -14772,9 +14773,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14792,9 +14790,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14812,9 +14807,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14832,9 +14824,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14852,9 +14841,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14872,9 +14858,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -20737,6 +20720,15 @@
         "url": "https://github.com/fb55/domhandler?sponsor=1"
       }
     },
+    "node_modules/dompurify": {
+      "version": "3.4.9",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.9.tgz",
+      "integrity": "sha512-4dPSRMRDqHvs0V4YDFCsaIZo4if5u0xM+llyxiM2fwuZFdKArUBAF3VtI2+n8NKg9P870WMdYk0UhqQNoWXbfQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
     "node_modules/domutils": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
@@ -26317,9 +26309,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -26341,9 +26330,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -26365,9 +26351,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -26389,9 +26372,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [


### PR DESCRIPTION
Closes #146 

- [x] New terms hosted and documented in RDFS
  - ~https://browser.pod-os.org/terms#htmlToolFragment~
  - https://pod-os.org/vocab/tools
  - [ ] tools:toolIndex from private preferences file
  - [ ] tools:ToolIndex
  - [ ] tools:registration
  - [ ] tools:TypeRegistration
  - [ ] tools:forClass
  - [ ] tools:HtmlTool
  - [ ] tools:htmlTool
  - [ ] tools:htmlToolFragment
- [ ] ADR to self-host core browser vocabulary
- [ ] When a resource is loaded, a matching ~pane~ tool definition is identified in the ~type index~ tool index
  - [ ]  A tool is added for each matching ~pane~ definition
  - [ ] New ~TypeIndex~ ToolIndex class in PodOS core
- [x] DOMPurify is applied to the HTML, and pos-label is whitelisted (which has no attributes)
- [x] The HTML is inserted into the page
- [x] The resource event is respected (init is not yet tested) and pos-label renders.

***
- [ ] Tests have been written
  - [x] all new code is covered by unit tests
  - [ ] the happy path of a new feature is covered by an end-to-end test
  - [ ] manual explorative tests have been performed
- [ ] all dependencies are updated to the latest patch version at minimum
- [ ] the [CI pipeline](https://github.com/pod-os/PodOS/actions) passes
- [ ] documentation is up-to-date
    - [ ] TSDoc style comments on important functions, properties and events
    - [ ] stories for new PodOS elements have been added to [storybook](../../storybook)
  - [ ] Readme.md files of PodOS elements have been re-generated
  - [ ] architectural decisions are documented as an [ADR](../decisions/0000-use-markdown-architectural-decision-records.md)
  - [ ] Changelogs are updated according to
        [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)