### PR TITLE
Reactive pos-label and pos-description

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 0.29.0
 
 ### Added
 

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- [`Thing.observeAnyValue`](https://pod-os.org/reference/core/classes/thing/#observeanyvalue) pushes changes to the value of predicates
+- [`Thing.observeLabel`](https://pod-os.org/reference/core/classes/thing/#observelabel) pushes changes to labels
+- [`Thing.observeDescription`](https://pod-os.org/reference/core/classes/thing/#observedescription) pushes changes to descriptions
+
 ## 0.28.0
 
 - [`addRelation`](https://pod-os.org/reference/core/classes/podos/#addrelation: A method to add a relation (link) between things

--- a/core/src/thing/Thing.anyValue.spec.ts
+++ b/core/src/thing/Thing.anyValue.spec.ts
@@ -1,7 +1,8 @@
-import { graph, IndexedFormula, sym } from "rdflib";
+import { graph, IndexedFormula, literal, quad, sym } from "rdflib";
 import { PodOsSession } from "../authentication";
 import { Thing } from "./Thing";
 import { Store } from "../Store";
+import { Subscription } from "rxjs";
 
 describe("Thing", function () {
   describe("any value", () => {
@@ -89,6 +90,163 @@ describe("Thing", function () {
       const result = it.anyValue(predicate, predicate, predicate);
 
       expect(result).toBe("test value");
+    });
+  });
+
+  describe("observeAnyValue", () => {
+    jest.useFakeTimers();
+
+    let internalStore: IndexedFormula,
+      subscriber: jest.Mock,
+      uri: string,
+      predicate: string,
+      anyValueSpy: jest.SpyInstance,
+      subscription: Subscription;
+
+    beforeEach(() => {
+      // Given a store with statements about a URI
+      internalStore = graph();
+      uri = "https://jane.doe.example/container/file.ttl#fragment";
+      predicate = "https://vocab.test/predicate";
+      internalStore.add(sym(uri), sym(predicate), "literal value");
+      internalStore.add(
+        sym(uri),
+        sym("https://vocab.test/other-predicate"),
+        "literal value",
+      );
+
+      const mockSession = {} as unknown as PodOsSession;
+      const store = new Store(mockSession, undefined, undefined, internalStore);
+
+      // and a Thing with a anyValue method
+      subscriber = jest.fn();
+      const thing = new Thing(uri, store);
+      anyValueSpy = jest.spyOn(thing, "anyValue");
+
+      // and a subscription to changes in value
+      const observable = thing.observeAnyValue(predicate);
+      subscription = observable.subscribe(subscriber);
+    });
+
+    it("pushes existing value immediately", () => {
+      expect(anyValueSpy).toHaveBeenCalledTimes(1);
+      expect(subscriber).toHaveBeenCalledTimes(1);
+      expect(subscriber.mock.calls).toEqual([["literal value"]]);
+    });
+
+    it("pushes undefined if single existing value is removed", () => {
+      internalStore.removeStatement(
+        quad(sym(uri), sym(predicate), literal("literal value")),
+      );
+      jest.advanceTimersByTime(250);
+      expect(anyValueSpy).toHaveBeenCalledTimes(2);
+      expect(subscriber).toHaveBeenCalledTimes(2);
+      expect(subscriber.mock.lastCall).toEqual([undefined]);
+    });
+
+    it("stops pushing after unsubscribe", () => {
+      subscription.unsubscribe();
+      internalStore.removeStatement(
+        quad(sym(uri), sym(predicate), literal("literal value")),
+      );
+      jest.advanceTimersByTime(250);
+      expect(subscriber).toHaveBeenCalledTimes(1);
+      expect(anyValueSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("ignores irrelevant removal", () => {
+      internalStore.removeStatement(
+        quad(
+          sym(uri),
+          sym("https://vocab.test/other-predicate"),
+          literal("literal value"),
+        ),
+      );
+      jest.advanceTimersByTime(250);
+      expect(anyValueSpy).toHaveBeenCalledTimes(1);
+      expect(subscriber).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not change if a value is already present", () => {
+      internalStore.add(sym(uri), sym(predicate), "literal value 2");
+      jest.advanceTimersByTime(250);
+      expect(anyValueSpy).toHaveBeenCalledTimes(1);
+      expect(subscriber).toHaveBeenCalledTimes(1);
+    });
+
+    it("pushes in groups", () => {
+      internalStore.removeStatement(
+        quad(sym(uri), sym(predicate), literal("literal value")),
+      );
+      internalStore.add(sym(uri), sym(predicate), "new literal value");
+      jest.advanceTimersByTime(250);
+      expect(subscriber).toHaveBeenCalledTimes(2);
+    });
+
+    it("pushes a value if none was present, without calling anyValue again", () => {
+      internalStore.removeStatement(
+        quad(sym(uri), sym(predicate), literal("literal value")),
+      );
+      internalStore.add(sym(uri), sym(predicate), "new literal value");
+      jest.advanceTimersByTime(250);
+      expect(anyValueSpy).toHaveBeenCalledTimes(1);
+      expect(subscriber.mock.lastCall).toEqual(["new literal value"]);
+    });
+
+    it("pushes a different value when one is removed if multiple are present", () => {
+      internalStore.add(sym(uri), sym(predicate), "literal value 2");
+      internalStore.removeStatement(
+        quad(sym(uri), sym(predicate), literal("literal value")),
+      );
+      jest.advanceTimersByTime(250);
+      expect(anyValueSpy).toHaveBeenCalledTimes(2);
+      expect(subscriber.mock.lastCall).toEqual(["literal value 2"]);
+    });
+
+    it("does not change again until next removal", () => {
+      internalStore.removeStatement(
+        quad(sym(uri), sym(predicate), literal("literal value")),
+      );
+      internalStore.add(
+        quad(sym(uri), sym(predicate), literal("literal value 2")),
+      );
+      jest.advanceTimersByTime(250);
+      expect(anyValueSpy).toHaveBeenCalledTimes(1);
+      expect(subscriber).toHaveBeenCalledTimes(2);
+      expect(subscriber.mock.lastCall).toEqual(["literal value 2"]);
+
+      internalStore.add(
+        quad(sym(uri), sym(predicate), literal("literal value 3")),
+      );
+      jest.advanceTimersByTime(250);
+      expect(anyValueSpy).toHaveBeenCalledTimes(1);
+      expect(subscriber).toHaveBeenCalledTimes(2);
+
+      internalStore.removeStatement(
+        quad(sym(uri), sym(predicate), literal("literal value 2")),
+      );
+      jest.advanceTimersByTime(250);
+      expect(anyValueSpy).toHaveBeenCalledTimes(2);
+      expect(subscriber).toHaveBeenCalledTimes(3);
+      expect(subscriber.mock.lastCall).toEqual(["literal value 3"]);
+    });
+
+    it("ignores irrelevant addition", () => {
+      internalStore.removeStatement(
+        quad(sym(uri), sym(predicate), literal("literal value")),
+      );
+      internalStore.add(
+        sym(uri),
+        sym("https://vocab.test/other-predicate"),
+        literal("wrong literal value"),
+      );
+      internalStore.add(
+        sym(uri),
+        sym(predicate),
+        literal("right literal value"),
+      );
+      jest.advanceTimersByTime(250);
+      expect(subscriber.mock.lastCall).toEqual(["right literal value"]);
     });
   });
 });

--- a/core/src/thing/Thing.anyValue.spec.ts
+++ b/core/src/thing/Thing.anyValue.spec.ts
@@ -393,6 +393,30 @@ describe("Thing", function () {
           // Then: should fall back to predicateB
           expect(subscriber).toHaveBeenCalledWith("value-b");
         });
+
+        it("keeps value from first predicate if second one gets a value after that", () => {
+          // Given multiple predicates are observed
+          const uri = "https://jane.doe.example/container/file.ttl#fragment";
+          const predicateA = "https://vocab.test/predicate-a";
+          const predicateB = "https://vocab.test/predicate-b";
+
+          const thing = new Thing(uri, store);
+          const subscriber = jest.fn();
+          const observable = thing.observeAnyValue(predicateA, predicateB);
+          observable.subscribe(subscriber);
+
+          // and predicateB has value
+          internalStore.add(sym(uri), sym(predicateB), "value-b");
+          jest.advanceTimersByTime(250);
+          expect(subscriber.mock.calls).toEqual([[undefined], ["value-b"]]);
+
+          // When predicateA gets a value while predicate B still has value
+          internalStore.add(sym(uri), sym(predicateA), "value-a");
+          jest.advanceTimersByTime(250);
+
+          // Then no change occurs because we have one from predicateA
+          expect(subscriber.mock.calls).toEqual([[undefined], ["value-b"]]);
+        });
       });
 
       describe("Multiple Values Per Predicate", () => {

--- a/core/src/thing/Thing.anyValue.spec.ts
+++ b/core/src/thing/Thing.anyValue.spec.ts
@@ -263,7 +263,7 @@ describe("Thing", function () {
     });
 
     // TODO make this green
-    it.skip("emits new value after add-remove-add cycle", () => {
+    it("emits new value after add-remove-add cycle", () => {
       // Given an empty store
       const internalStore = graph();
       const mockSession = {} as unknown as PodOsSession;

--- a/core/src/thing/Thing.anyValue.spec.ts
+++ b/core/src/thing/Thing.anyValue.spec.ts
@@ -96,205 +96,233 @@ describe("Thing", function () {
   describe("observeAnyValue", () => {
     jest.useFakeTimers();
 
-    let internalStore: IndexedFormula,
-      subscriber: jest.Mock,
-      uri: string,
-      predicate: string,
-      anyValueSpy: jest.SpyInstance,
-      subscription: Subscription;
+    describe("with pre-populated store", () => {
+      let internalStore: IndexedFormula,
+        subscriber: jest.Mock,
+        uri: string,
+        predicate: string,
+        anyValueSpy: jest.SpyInstance,
+        subscription: Subscription;
 
-    beforeEach(() => {
-      // Given a store with statements about a URI
-      internalStore = graph();
-      uri = "https://jane.doe.example/container/file.ttl#fragment";
-      predicate = "https://vocab.test/predicate";
-      internalStore.add(sym(uri), sym(predicate), "literal value");
-      internalStore.add(
-        sym(uri),
-        sym("https://vocab.test/other-predicate"),
-        "literal value",
-      );
-
-      const mockSession = {} as unknown as PodOsSession;
-      const store = new Store(mockSession, undefined, undefined, internalStore);
-
-      // and a Thing with a anyValue method
-      subscriber = jest.fn();
-      const thing = new Thing(uri, store);
-      anyValueSpy = jest.spyOn(thing, "anyValue");
-
-      // and a subscription to changes in value
-      const observable = thing.observeAnyValue(predicate);
-      subscription = observable.subscribe(subscriber);
-    });
-
-    it("pushes existing value immediately", () => {
-      expect(anyValueSpy).toHaveBeenCalledTimes(1);
-      expect(subscriber).toHaveBeenCalledTimes(1);
-      expect(subscriber.mock.calls).toEqual([["literal value"]]);
-    });
-
-    it("pushes undefined if single existing value is removed", () => {
-      internalStore.removeStatement(
-        quad(sym(uri), sym(predicate), literal("literal value")),
-      );
-      jest.advanceTimersByTime(250);
-      expect(anyValueSpy).toHaveBeenCalledTimes(2);
-      expect(subscriber).toHaveBeenCalledTimes(2);
-      expect(subscriber.mock.lastCall).toEqual([undefined]);
-    });
-
-    it("stops pushing after unsubscribe", () => {
-      subscription.unsubscribe();
-      internalStore.removeStatement(
-        quad(sym(uri), sym(predicate), literal("literal value")),
-      );
-      jest.advanceTimersByTime(250);
-      expect(subscriber).toHaveBeenCalledTimes(1);
-      expect(anyValueSpy).toHaveBeenCalledTimes(1);
-    });
-
-    it("ignores irrelevant removal", () => {
-      internalStore.removeStatement(
-        quad(
+      beforeEach(() => {
+        // Given a store with statements about a URI
+        internalStore = graph();
+        uri = "https://jane.doe.example/container/file.ttl#fragment";
+        predicate = "https://vocab.test/predicate";
+        internalStore.add(sym(uri), sym(predicate), "literal value");
+        internalStore.add(
           sym(uri),
           sym("https://vocab.test/other-predicate"),
-          literal("literal value"),
-        ),
-      );
-      jest.advanceTimersByTime(250);
-      expect(anyValueSpy).toHaveBeenCalledTimes(1);
-      expect(subscriber).toHaveBeenCalledTimes(1);
+          "literal value",
+        );
+
+        const mockSession = {} as unknown as PodOsSession;
+        const store = new Store(
+          mockSession,
+          undefined,
+          undefined,
+          internalStore,
+        );
+
+        // and a Thing with a anyValue method
+        subscriber = jest.fn();
+        const thing = new Thing(uri, store);
+        anyValueSpy = jest.spyOn(thing, "anyValue");
+
+        // and a subscription to changes in value
+        const observable = thing.observeAnyValue(predicate);
+        subscription = observable.subscribe(subscriber);
+      });
+
+      it("pushes existing value immediately", () => {
+        expect(anyValueSpy).toHaveBeenCalledTimes(1);
+        expect(subscriber).toHaveBeenCalledTimes(1);
+        expect(subscriber.mock.calls).toEqual([["literal value"]]);
+      });
+
+      it("pushes undefined if single existing value is removed", () => {
+        internalStore.removeStatement(
+          quad(sym(uri), sym(predicate), literal("literal value")),
+        );
+        jest.advanceTimersByTime(250);
+        expect(anyValueSpy).toHaveBeenCalledTimes(2);
+        expect(subscriber).toHaveBeenCalledTimes(2);
+        expect(subscriber.mock.lastCall).toEqual([undefined]);
+      });
+
+      it("stops pushing after unsubscribe", () => {
+        subscription.unsubscribe();
+        internalStore.removeStatement(
+          quad(sym(uri), sym(predicate), literal("literal value")),
+        );
+        jest.advanceTimersByTime(250);
+        expect(subscriber).toHaveBeenCalledTimes(1);
+        expect(anyValueSpy).toHaveBeenCalledTimes(1);
+      });
+
+      it("ignores irrelevant removal", () => {
+        internalStore.removeStatement(
+          quad(
+            sym(uri),
+            sym("https://vocab.test/other-predicate"),
+            literal("literal value"),
+          ),
+        );
+        jest.advanceTimersByTime(250);
+        expect(anyValueSpy).toHaveBeenCalledTimes(1);
+        expect(subscriber).toHaveBeenCalledTimes(1);
+      });
+
+      it("does not change if a value is already present", () => {
+        internalStore.add(sym(uri), sym(predicate), "literal value 2");
+        jest.advanceTimersByTime(250);
+        expect(anyValueSpy).toHaveBeenCalledTimes(1);
+        expect(subscriber).toHaveBeenCalledTimes(1);
+      });
+
+      it("pushes in groups", () => {
+        internalStore.removeStatement(
+          quad(sym(uri), sym(predicate), literal("literal value")),
+        );
+        internalStore.add(sym(uri), sym(predicate), "new literal value");
+        jest.advanceTimersByTime(250);
+        expect(subscriber).toHaveBeenCalledTimes(2);
+      });
+
+      it("pushes a different value when one is removed if multiple are present", () => {
+        internalStore.add(sym(uri), sym(predicate), "literal value 2");
+        internalStore.removeStatement(
+          quad(sym(uri), sym(predicate), literal("literal value")),
+        );
+        jest.advanceTimersByTime(250);
+        expect(anyValueSpy).toHaveBeenCalledTimes(2);
+        expect(subscriber.mock.lastCall).toEqual(["literal value 2"]);
+      });
+
+      it("does not change again until next removal", () => {
+        internalStore.removeStatement(
+          quad(sym(uri), sym(predicate), literal("literal value")),
+        );
+        internalStore.add(
+          quad(sym(uri), sym(predicate), literal("literal value 2")),
+        );
+        jest.advanceTimersByTime(250);
+        expect(anyValueSpy).toHaveBeenCalledTimes(1);
+        expect(subscriber).toHaveBeenCalledTimes(2);
+        expect(subscriber.mock.lastCall).toEqual(["literal value 2"]);
+
+        internalStore.add(
+          quad(sym(uri), sym(predicate), literal("literal value 3")),
+        );
+        jest.advanceTimersByTime(250);
+        expect(anyValueSpy).toHaveBeenCalledTimes(1);
+        expect(subscriber).toHaveBeenCalledTimes(2);
+
+        internalStore.removeStatement(
+          quad(sym(uri), sym(predicate), literal("literal value 2")),
+        );
+        jest.advanceTimersByTime(250);
+        expect(anyValueSpy).toHaveBeenCalledTimes(2);
+        expect(subscriber).toHaveBeenCalledTimes(3);
+        expect(subscriber.mock.lastCall).toEqual(["literal value 3"]);
+      });
+
+      it("ignores irrelevant addition", () => {
+        internalStore.removeStatement(
+          quad(sym(uri), sym(predicate), literal("literal value")),
+        );
+        internalStore.add(
+          sym(uri),
+          sym("https://vocab.test/other-predicate"),
+          literal("wrong literal value"),
+        );
+        internalStore.add(
+          sym(uri),
+          sym(predicate),
+          literal("right literal value"),
+        );
+        jest.advanceTimersByTime(250);
+        expect(subscriber.mock.lastCall).toEqual(["right literal value"]);
+      });
     });
 
-    it("does not change if a value is already present", () => {
-      internalStore.add(sym(uri), sym(predicate), "literal value 2");
-      jest.advanceTimersByTime(250);
-      expect(anyValueSpy).toHaveBeenCalledTimes(1);
-      expect(subscriber).toHaveBeenCalledTimes(1);
-    });
+    describe("a store without any statements yet", () => {
+      let internalStore: IndexedFormula,
+        subscriber: jest.Mock,
+        uri: string,
+        predicate: string,
+        anyValueSpy: jest.SpyInstance,
+        subscription: Subscription,
+        store: Store;
 
-    it("pushes in groups", () => {
-      internalStore.removeStatement(
-        quad(sym(uri), sym(predicate), literal("literal value")),
-      );
-      internalStore.add(sym(uri), sym(predicate), "new literal value");
-      jest.advanceTimersByTime(250);
-      expect(subscriber).toHaveBeenCalledTimes(2);
-    });
+      beforeEach(() => {
+        // Given a store without any statements yet
+        internalStore = graph();
+        uri = "https://jane.doe.example/container/file.ttl#fragment";
+        predicate = "https://vocab.test/predicate";
 
-    it("pushes a value if none was present, without calling anyValue again", () => {
-      // Given an empty store
-      const internalStore = graph();
-      const mockSession = {} as unknown as PodOsSession;
-      const store = new Store(mockSession, undefined, undefined, internalStore);
-      // and a thing
-      const thing = new Thing(uri, store);
-      const anyValueSpy = jest.spyOn(thing, "anyValue");
+        const mockSession = {} as unknown as PodOsSession;
+        store = new Store(mockSession, undefined, undefined, internalStore);
 
-      const observable = thing.observeAnyValue(predicate);
-      const subscriber = jest.fn();
-      observable.subscribe(subscriber);
+        // and a Thing with a anyValue method
+        subscriber = jest.fn();
+        const thing = new Thing(uri, store);
+        anyValueSpy = jest.spyOn(thing, "anyValue");
 
-      internalStore.add(sym(uri), sym(predicate), "new literal value");
-      jest.advanceTimersByTime(250);
-      expect(anyValueSpy).toHaveBeenCalledTimes(1);
-      expect(subscriber).toHaveBeenCalledTimes(2);
-      expect(subscriber.mock.calls).toEqual([
-        [undefined],
-        ["new literal value"],
-      ]);
-    });
+        // and a subscription to changes in value
+        const observable = thing.observeAnyValue(predicate);
+        subscription = observable.subscribe(subscriber);
+      });
 
-    it("pushes a different value when one is removed if multiple are present", () => {
-      internalStore.add(sym(uri), sym(predicate), "literal value 2");
-      internalStore.removeStatement(
-        quad(sym(uri), sym(predicate), literal("literal value")),
-      );
-      jest.advanceTimersByTime(250);
-      expect(anyValueSpy).toHaveBeenCalledTimes(2);
-      expect(subscriber.mock.lastCall).toEqual(["literal value 2"]);
-    });
+      afterEach(() => {
+        subscription.unsubscribe();
+      });
 
-    it("does not change again until next removal", () => {
-      internalStore.removeStatement(
-        quad(sym(uri), sym(predicate), literal("literal value")),
-      );
-      internalStore.add(
-        quad(sym(uri), sym(predicate), literal("literal value 2")),
-      );
-      jest.advanceTimersByTime(250);
-      expect(anyValueSpy).toHaveBeenCalledTimes(1);
-      expect(subscriber).toHaveBeenCalledTimes(2);
-      expect(subscriber.mock.lastCall).toEqual(["literal value 2"]);
+      it("pushes a value if none was present, without calling anyValue again", () => {
+        // when the first value for that predicate occurs
+        internalStore.add(sym(uri), sym(predicate), "new literal value");
+        jest.advanceTimersByTime(250);
 
-      internalStore.add(
-        quad(sym(uri), sym(predicate), literal("literal value 3")),
-      );
-      jest.advanceTimersByTime(250);
-      expect(anyValueSpy).toHaveBeenCalledTimes(1);
-      expect(subscriber).toHaveBeenCalledTimes(2);
+        // then the subscriber receives both the initial undefined and the new value
+        expect(subscriber).toHaveBeenCalledTimes(2);
+        expect(subscriber.mock.calls).toEqual([
+          [undefined],
+          ["new literal value"],
+        ]);
 
-      internalStore.removeStatement(
-        quad(sym(uri), sym(predicate), literal("literal value 2")),
-      );
-      jest.advanceTimersByTime(250);
-      expect(anyValueSpy).toHaveBeenCalledTimes(2);
-      expect(subscriber).toHaveBeenCalledTimes(3);
-      expect(subscriber.mock.lastCall).toEqual(["literal value 3"]);
-    });
+        // but anyValue was ony called once
+        expect(anyValueSpy).toHaveBeenCalledTimes(1);
+      });
 
-    it("ignores irrelevant addition", () => {
-      internalStore.removeStatement(
-        quad(sym(uri), sym(predicate), literal("literal value")),
-      );
-      internalStore.add(
-        sym(uri),
-        sym("https://vocab.test/other-predicate"),
-        literal("wrong literal value"),
-      );
-      internalStore.add(
-        sym(uri),
-        sym(predicate),
-        literal("right literal value"),
-      );
-      jest.advanceTimersByTime(250);
-      expect(subscriber.mock.lastCall).toEqual(["right literal value"]);
-    });
+      it("emits new value after add-remove-add cycle", () => {
+        // Given a thing observing multiple predicates
+        const uri = "https://jane.doe.example/container/file.ttl#fragment";
+        const predicateA = "https://vocab.test/predicate-a";
+        const predicateB = "https://vocab.test/predicate-b";
 
-    // TODO make this green
-    it("emits new value after add-remove-add cycle", () => {
-      // Given an empty store
-      const internalStore = graph();
-      const mockSession = {} as unknown as PodOsSession;
-      const store = new Store(mockSession, undefined, undefined, internalStore);
-      const uri = "https://jane.doe.example/container/file.ttl#fragment";
-      const predicateA = "https://vocab.test/predicate-a";
-      const predicateB = "https://vocab.test/predicate-b";
+        const thing = new Thing(uri, store);
+        const subscriber = jest.fn();
+        const observable = thing.observeAnyValue(predicateA, predicateB);
+        observable.subscribe(subscriber);
 
-      // and a thing observing multiple predicates
-      const thing = new Thing(uri, store);
-      const subscriber = jest.fn();
-      const observable = thing.observeAnyValue(predicateA, predicateB);
-      observable.subscribe(subscriber);
+        // When: undefined → +a → -a → +b
+        expect(subscriber).toHaveBeenCalledWith(undefined);
 
-      // When: undefined → +a → -a → +b
-      expect(subscriber).toHaveBeenCalledWith(undefined);
+        const valueAQuad = quad(sym(uri), sym(predicateA), literal("value A"));
+        internalStore.add(valueAQuad);
+        jest.advanceTimersByTime(250);
+        expect(subscriber).toHaveBeenCalledWith("value A");
 
-      const valueAQuad = quad(sym(uri), sym(predicateA), literal("value A"));
-      internalStore.add(valueAQuad);
-      jest.advanceTimersByTime(250);
-      expect(subscriber).toHaveBeenCalledWith("value A");
+        internalStore.removeStatement(valueAQuad);
+        jest.advanceTimersByTime(250);
+        expect(subscriber).toHaveBeenCalledWith(undefined);
 
-      internalStore.removeStatement(valueAQuad);
-      jest.advanceTimersByTime(250);
-      expect(subscriber).toHaveBeenCalledWith(undefined);
+        internalStore.add(sym(uri), sym(predicateB), "value B");
+        jest.advanceTimersByTime(250);
 
-      internalStore.add(sym(uri), sym(predicateB), "value B");
-      jest.advanceTimersByTime(250);
-
-      // Then: should emit "value B"
-      expect(subscriber).toHaveBeenCalledWith("value B");
+        // Then: should emit "value B"
+        expect(subscriber).toHaveBeenCalledWith("value B");
+      });
     });
   });
 });

--- a/core/src/thing/Thing.anyValue.spec.ts
+++ b/core/src/thing/Thing.anyValue.spec.ts
@@ -184,13 +184,26 @@ describe("Thing", function () {
     });
 
     it("pushes a value if none was present, without calling anyValue again", () => {
-      internalStore.removeStatement(
-        quad(sym(uri), sym(predicate), literal("literal value")),
-      );
+      // Given an empty store
+      const internalStore = graph();
+      const mockSession = {} as unknown as PodOsSession;
+      const store = new Store(mockSession, undefined, undefined, internalStore);
+      // and a thing
+      const thing = new Thing(uri, store);
+      const anyValueSpy = jest.spyOn(thing, "anyValue");
+
+      const observable = thing.observeAnyValue(predicate);
+      const subscriber = jest.fn();
+      observable.subscribe(subscriber);
+
       internalStore.add(sym(uri), sym(predicate), "new literal value");
       jest.advanceTimersByTime(250);
       expect(anyValueSpy).toHaveBeenCalledTimes(1);
-      expect(subscriber.mock.lastCall).toEqual(["new literal value"]);
+      expect(subscriber).toHaveBeenCalledTimes(2);
+      expect(subscriber.mock.calls).toEqual([
+        [undefined],
+        ["new literal value"],
+      ]);
     });
 
     it("pushes a different value when one is removed if multiple are present", () => {

--- a/core/src/thing/Thing.anyValue.spec.ts
+++ b/core/src/thing/Thing.anyValue.spec.ts
@@ -261,5 +261,40 @@ describe("Thing", function () {
       jest.advanceTimersByTime(250);
       expect(subscriber.mock.lastCall).toEqual(["right literal value"]);
     });
+
+    // TODO make this green
+    it.skip("emits new value after add-remove-add cycle", () => {
+      // Given an empty store
+      const internalStore = graph();
+      const mockSession = {} as unknown as PodOsSession;
+      const store = new Store(mockSession, undefined, undefined, internalStore);
+      const uri = "https://jane.doe.example/container/file.ttl#fragment";
+      const predicateA = "https://vocab.test/predicate-a";
+      const predicateB = "https://vocab.test/predicate-b";
+
+      // and a thing observing multiple predicates
+      const thing = new Thing(uri, store);
+      const subscriber = jest.fn();
+      const observable = thing.observeAnyValue(predicateA, predicateB);
+      observable.subscribe(subscriber);
+
+      // When: undefined → +a → -a → +b
+      expect(subscriber).toHaveBeenCalledWith(undefined);
+
+      const valueAQuad = quad(sym(uri), sym(predicateA), literal("value A"));
+      internalStore.add(valueAQuad);
+      jest.advanceTimersByTime(250);
+      expect(subscriber).toHaveBeenCalledWith("value A");
+
+      internalStore.removeStatement(valueAQuad);
+      jest.advanceTimersByTime(250);
+      expect(subscriber).toHaveBeenCalledWith(undefined);
+
+      internalStore.add(sym(uri), sym(predicateB), "value B");
+      jest.advanceTimersByTime(250);
+
+      // Then: should emit "value B"
+      expect(subscriber).toHaveBeenCalledWith("value B");
+    });
   });
 });

--- a/core/src/thing/Thing.anyValue.spec.ts
+++ b/core/src/thing/Thing.anyValue.spec.ts
@@ -500,6 +500,80 @@ describe("Thing", function () {
           jest.advanceTimersByTime(250);
           expect(subscriber).toHaveBeenCalledWith("value-a2");
         });
+
+        it("handles interleaved additions and removals across predicates", () => {
+          // Given: two predicates are observed
+          const uri = "https://jane.doe.example/container/file.ttl#fragment";
+          const predicateA = "https://vocab.test/predicate-a";
+          const predicateB = "https://vocab.test/predicate-b";
+
+          const thing = new Thing(uri, store);
+          const subscriber = jest.fn();
+          const observable = thing.observeAnyValue(predicateA, predicateB);
+          observable.subscribe(subscriber);
+
+          // And store has: predicateA=value-a
+          internalStore.add(sym(uri), sym(predicateA), "value-a");
+          jest.advanceTimersByTime(250);
+          expect(subscriber).toHaveBeenCalledWith("value-a");
+
+          // When: +predicateB=value-b (while predicateA still has value-a)
+          internalStore.add(sym(uri), sym(predicateB), "value-b");
+          jest.advanceTimersByTime(250);
+          // Then: should not emit (predicateA already had value, new value doesn't change "any")
+          expect(subscriber.mock.calls.length).toBe(2); // still only 2: undefined, value-a
+
+          // When: -predicateA=value-a
+          internalStore.removeMatches(
+            sym(uri),
+            sym(predicateA),
+            literal("value-a"),
+          );
+          jest.advanceTimersByTime(250);
+          // Then: should emit value-b (now predicateA is gone, fall back to predicateB)
+          expect(subscriber).toHaveBeenCalledWith("value-b");
+        });
+      });
+
+      it("handles transitions from undefined to defined to undefined to defined", () => {
+        // Given: observeAnyValue(predicate) on empty store
+        const uri = "https://jane.doe.example/container/file.ttl#fragment";
+        const predicate = "https://vocab.test/predicate";
+
+        const thing = new Thing(uri, store);
+        const subscriber = jest.fn();
+        const observable = thing.observeAnyValue(predicate);
+        observable.subscribe(subscriber);
+
+        // Then: -empty (initial) → undefined
+        expect(subscriber).toHaveBeenCalledWith(undefined);
+
+        // When: +value-a → value-a
+        internalStore.add(sym(uri), sym(predicate), "value-a");
+        jest.advanceTimersByTime(250);
+        expect(subscriber).toHaveBeenCalledWith("value-a");
+
+        // When: -value-a → undefined
+        internalStore.removeMatches(
+          sym(uri),
+          sym(predicate),
+          literal("value-a"),
+        );
+        jest.advanceTimersByTime(250);
+        expect(subscriber).toHaveBeenCalledWith(undefined);
+
+        // When: +value-b → value-b
+        internalStore.add(sym(uri), sym(predicate), "value-b");
+        jest.advanceTimersByTime(250);
+        expect(subscriber).toHaveBeenCalledWith("value-b");
+
+        // Then: verify all emissions
+        expect(subscriber.mock.calls).toEqual([
+          [undefined],
+          ["value-a"],
+          [undefined],
+          ["value-b"],
+        ]);
       });
 
       describe("Consistency with anyValue() semantics", () => {

--- a/core/src/thing/Thing.anyValue.spec.ts
+++ b/core/src/thing/Thing.anyValue.spec.ts
@@ -420,6 +420,40 @@ describe("Thing", function () {
       });
 
       describe("Multiple Values Per Predicate", () => {
+        it("emits last remaining value when all but one are removed", () => {
+          // Given: a store with three values for the same predicate
+          const uri = "https://jane.doe.example/container/file.ttl#fragment";
+          const predicate = "https://vocab.test/predicate";
+
+          internalStore.add(sym(uri), sym(predicate), "value1");
+          internalStore.add(sym(uri), sym(predicate), "value2");
+          internalStore.add(sym(uri), sym(predicate), "value3");
+
+          const thing = new Thing(uri, store);
+          const subscriber = jest.fn();
+          const observable = thing.observeAnyValue(predicate);
+          observable.subscribe(subscriber);
+
+          expect(subscriber.mock.calls[0]).toEqual(["value1"]);
+
+          // When: value1 and value2 are removed
+          internalStore.removeMatches(
+            sym(uri),
+            sym(predicate),
+            literal("value1"),
+          );
+          internalStore.removeMatches(
+            sym(uri),
+            sym(predicate),
+            literal("value2"),
+          );
+          jest.advanceTimersByTime(250);
+
+          // Then: should emit value3 (the last remaining)
+          expect(subscriber).toHaveBeenCalledWith("value3");
+          expect(subscriber.mock.lastCall).toEqual(["value3"]);
+        });
+
         it("emits next value when first value removed if multiple exist", () => {
           // Given: a store with multiple values for the same predicate
           const uri = "https://jane.doe.example/container/file.ttl#fragment";
@@ -501,6 +535,51 @@ describe("Thing", function () {
           expect(subscriber).toHaveBeenCalledWith("value-a2");
         });
 
+        it("emits undefined once when all predicates lose all values in same debounce window", () => {
+          // Given: three predicates all have values
+          const uri = "https://jane.doe.example/container/file.ttl#fragment";
+          const predicateA = "https://vocab.test/predicate-a";
+          const predicateB = "https://vocab.test/predicate-b";
+          const predicateC = "https://vocab.test/predicate-c";
+
+          internalStore.add(sym(uri), sym(predicateA), "value-a");
+          internalStore.add(sym(uri), sym(predicateB), "value-b");
+          internalStore.add(sym(uri), sym(predicateC), "value-c");
+
+          const thing = new Thing(uri, store);
+          const subscriber = jest.fn();
+          const observable = thing.observeAnyValue(
+            predicateA,
+            predicateB,
+            predicateC,
+          );
+          observable.subscribe(subscriber);
+
+          expect(subscriber.mock.calls[0]).toEqual(["value-a"]);
+
+          // When: all values removed in same debounce window
+          internalStore.removeMatches(
+            sym(uri),
+            sym(predicateA),
+            literal("value-a"),
+          );
+          internalStore.removeMatches(
+            sym(uri),
+            sym(predicateB),
+            literal("value-b"),
+          );
+          internalStore.removeMatches(
+            sym(uri),
+            sym(predicateC),
+            literal("value-c"),
+          );
+          jest.advanceTimersByTime(250);
+
+          // Then: should emit undefined exactly once
+          expect(subscriber).toHaveBeenCalledTimes(2);
+          expect(subscriber.mock.lastCall).toEqual([undefined]);
+        });
+
         it("handles interleaved additions and removals across predicates", () => {
           // Given: two predicates are observed
           const uri = "https://jane.doe.example/container/file.ttl#fragment";
@@ -574,6 +653,73 @@ describe("Thing", function () {
           [undefined],
           ["value-b"],
         ]);
+      });
+
+      describe("Rapid Changes and Debouncing", () => {
+        it("emits once when multiple values removed in same debounce window", () => {
+          // Given: a store with multiple values for the same predicate
+          const uri = "https://jane.doe.example/container/file.ttl#fragment";
+          const predicate = "https://vocab.test/predicate";
+
+          internalStore.add(sym(uri), sym(predicate), "value1");
+          internalStore.add(sym(uri), sym(predicate), "value2");
+          internalStore.add(sym(uri), sym(predicate), "value3");
+
+          const thing = new Thing(uri, store);
+          const subscriber = jest.fn();
+
+          // And: subscribing to the predicate
+          const observable = thing.observeAnyValue(predicate);
+          observable.subscribe(subscriber);
+
+          // And: initial value is the first one
+          expect(subscriber.mock.calls[0]).toEqual(["value1"]);
+
+          // When: value1 and value2 are removed in the same debounce window
+          internalStore.removeMatches(
+            sym(uri),
+            sym(predicate),
+            literal("value1"),
+          );
+          internalStore.removeMatches(
+            sym(uri),
+            sym(predicate),
+            literal("value2"),
+          );
+          jest.advanceTimersByTime(250);
+
+          // Then: should emit once with value3 (not twice)
+          expect(subscriber).toHaveBeenCalledTimes(2);
+          expect(subscriber.mock.lastCall).toEqual(["value3"]);
+        });
+
+        it("emits once with new value when remove-then-add happen in same debounce window", () => {
+          // Given: a store with one value
+          const uri = "https://jane.doe.example/container/file.ttl#fragment";
+          const predicate = "https://vocab.test/predicate";
+
+          internalStore.add(sym(uri), sym(predicate), "value-a");
+
+          const thing = new Thing(uri, store);
+          const subscriber = jest.fn();
+          const observable = thing.observeAnyValue(predicate);
+          observable.subscribe(subscriber);
+
+          expect(subscriber.mock.calls[0]).toEqual(["value-a"]);
+
+          // When: value-a removed and value-b added within the same debounce window
+          internalStore.removeMatches(
+            sym(uri),
+            sym(predicate),
+            literal("value-a"),
+          );
+          internalStore.add(sym(uri), sym(predicate), "value-b");
+          jest.advanceTimersByTime(250);
+
+          // Then: should emit only once with value-b (not undefined then value-b)
+          expect(subscriber).toHaveBeenCalledTimes(2);
+          expect(subscriber.mock.lastCall).toEqual(["value-b"]);
+        });
       });
 
       describe("Consistency with anyValue() semantics", () => {

--- a/core/src/thing/Thing.anyValue.spec.ts
+++ b/core/src/thing/Thing.anyValue.spec.ts
@@ -323,6 +323,195 @@ describe("Thing", function () {
         // Then: should emit "value B"
         expect(subscriber).toHaveBeenCalledWith("value B");
       });
+
+      describe("Multiple Predicates", () => {
+        it("picks first predicate when multiple have values in initial state", () => {
+          // Given: a store with values for multiple predicates
+          const uri = "https://jane.doe.example/container/file.ttl#fragment";
+          const predicateA = "https://vocab.test/predicate-a";
+          const predicateB = "https://vocab.test/predicate-b";
+          const predicateC = "https://vocab.test/predicate-c";
+
+          internalStore.add(sym(uri), sym(predicateA), "value-a");
+          internalStore.add(sym(uri), sym(predicateB), "value-b");
+          internalStore.add(sym(uri), sym(predicateC), "value-c");
+
+          const thing = new Thing(uri, store);
+          const subscriber = jest.fn();
+
+          // When: subscribing to multiple predicates
+          const observable = thing.observeAnyValue(
+            predicateA,
+            predicateB,
+            predicateC,
+          );
+          observable.subscribe(subscriber);
+
+          // Then: first emission should be the value of the first predicate
+          expect(subscriber).toHaveBeenCalledTimes(1);
+          expect(subscriber.mock.calls[0]).toEqual(["value-a"]);
+        });
+
+        it("falls back to second predicate when all values removed from first", () => {
+          // Given: a store with multiple values on first predicate and one on second
+          const uri = "https://jane.doe.example/container/file.ttl#fragment";
+          const predicateA = "https://vocab.test/predicate-a";
+          const predicateB = "https://vocab.test/predicate-b";
+          const predicateC = "https://vocab.test/predicate-c";
+
+          internalStore.add(sym(uri), sym(predicateA), "value-a1");
+          internalStore.add(sym(uri), sym(predicateA), "value-a2");
+          internalStore.add(sym(uri), sym(predicateB), "value-b");
+
+          const thing = new Thing(uri, store);
+          const subscriber = jest.fn();
+
+          // And: subscribing to multiple predicates
+          const observable = thing.observeAnyValue(
+            predicateA,
+            predicateB,
+            predicateC,
+          );
+          observable.subscribe(subscriber);
+
+          // And: initial value is from predicateA
+          expect(subscriber.mock.calls[0]).toEqual(["value-a1"]);
+
+          // When: both values from predicateA are removed
+          internalStore.removeMatches(
+            sym(uri),
+            sym(predicateA),
+            literal("value-a1"),
+          );
+          internalStore.removeMatches(
+            sym(uri),
+            sym(predicateA),
+            literal("value-a2"),
+          );
+          jest.advanceTimersByTime(250);
+
+          // Then: should fall back to predicateB
+          expect(subscriber).toHaveBeenCalledWith("value-b");
+        });
+      });
+
+      describe("Multiple Values Per Predicate", () => {
+        it("emits next value when first value removed if multiple exist", () => {
+          // Given: a store with multiple values for the same predicate
+          const uri = "https://jane.doe.example/container/file.ttl#fragment";
+          const predicate = "https://vocab.test/predicate";
+
+          internalStore.add(sym(uri), sym(predicate), "value1");
+          internalStore.add(sym(uri), sym(predicate), "value2");
+          internalStore.add(sym(uri), sym(predicate), "value3");
+
+          const thing = new Thing(uri, store);
+          const subscriber = jest.fn();
+
+          // And: thing subscribing to the predicate
+          const observable = thing.observeAnyValue(predicate);
+          observable.subscribe(subscriber);
+
+          // And: initial value is the first one
+          expect(subscriber.mock.calls[0]).toEqual(["value1"]);
+
+          // When: the first value is removed
+          internalStore.removeMatches(
+            sym(uri),
+            sym(predicate),
+            literal("value1"),
+          );
+          jest.advanceTimersByTime(250);
+
+          // Then: should emit the next value
+          expect(subscriber).toHaveBeenCalledWith("value2");
+        });
+      });
+
+      describe("Additional Predicate Switching", () => {
+        it("switches between predicates back and forth", () => {
+          // Given: two predicates are observed
+          const uri = "https://jane.doe.example/container/file.ttl#fragment";
+          const predicateA = "https://vocab.test/predicate-a";
+          const predicateB = "https://vocab.test/predicate-b";
+
+          const thing = new Thing(uri, store);
+          const subscriber = jest.fn();
+          const observable = thing.observeAnyValue(predicateA, predicateB);
+          observable.subscribe(subscriber);
+
+          // And both have no value
+          expect(subscriber).toHaveBeenCalledWith(undefined);
+
+          // When: +predicateA=value-a → emit value-a
+          internalStore.add(sym(uri), sym(predicateA), "value-a");
+          jest.advanceTimersByTime(250);
+          expect(subscriber).toHaveBeenCalledWith("value-a");
+
+          // When: -predicateA=value-a → emit undefined
+          internalStore.removeMatches(
+            sym(uri),
+            sym(predicateA),
+            literal("value-a"),
+          );
+          jest.advanceTimersByTime(250);
+          expect(subscriber).toHaveBeenCalledWith(undefined);
+
+          // When: +predicateB=value-b → emit value-b
+          internalStore.add(sym(uri), sym(predicateB), "value-b");
+          jest.advanceTimersByTime(250);
+          expect(subscriber).toHaveBeenCalledWith("value-b");
+
+          // When: -predicateB=value-b → emit undefined
+          internalStore.removeMatches(
+            sym(uri),
+            sym(predicateB),
+            literal("value-b"),
+          );
+          jest.advanceTimersByTime(250);
+          expect(subscriber).toHaveBeenCalledWith(undefined);
+
+          // When: +predicateA=value-a2 → emit value-a2
+          internalStore.add(sym(uri), sym(predicateA), "value-a2");
+          jest.advanceTimersByTime(250);
+          expect(subscriber).toHaveBeenCalledWith("value-a2");
+        });
+      });
+
+      describe("Consistency with anyValue() semantics", () => {
+        it("first emission equals anyValue() at subscription time", () => {
+          // Given: a store with multiple predicates and values
+          const uri = "https://jane.doe.example/container/file.ttl#fragment";
+          const predicateA = "https://vocab.test/predicate-a";
+          const predicateB = "https://vocab.test/predicate-b";
+          const predicateC = "https://vocab.test/predicate-c";
+
+          internalStore.add(sym(uri), sym(predicateA), "value-a");
+          internalStore.add(sym(uri), sym(predicateB), "value-b");
+          internalStore.add(sym(uri), sym(predicateC), "value-c");
+
+          const thing = new Thing(uri, store);
+
+          // When: getting anyValue
+          const anyValueResult = thing.anyValue(
+            predicateA,
+            predicateB,
+            predicateC,
+          );
+
+          // And: observing anyValue
+          const subscriber = jest.fn();
+          const observable = thing.observeAnyValue(
+            predicateA,
+            predicateB,
+            predicateC,
+          );
+          observable.subscribe(subscriber);
+
+          // Then: first emission should equal anyValue result
+          expect(subscriber.mock.calls[0][0]).toEqual(anyValueResult);
+        });
+      });
     });
   });
 });

--- a/core/src/thing/Thing.description.spec.ts
+++ b/core/src/thing/Thing.description.spec.ts
@@ -1,4 +1,4 @@
-import { graph, IndexedFormula, sym } from "rdflib";
+import { graph, IndexedFormula, literal, quad, sym } from "rdflib";
 import { PodOsSession } from "../authentication";
 import { Thing } from "./Thing";
 import { Store } from "../Store";
@@ -14,7 +14,7 @@ describe("Thing", function () {
   });
 
   describe("description", () => {
-    it("is the undefined if nothing is found in store", () => {
+    it("is undefined if nothing is found in store", () => {
       const it = new Thing(
         "https://jane.doe.example/container/file.ttl#fragment",
         store,
@@ -41,6 +41,134 @@ describe("Thing", function () {
       );
       const result = it.description();
       expect(result).toEqual("literal value");
+    });
+  });
+
+  describe("observeDescription", () => {
+    const uri = "https://jane.doe.example/container/file.ttl#fragment";
+
+    it("pushes existing value immediately", () => {
+      // Given a store with a URI with a description
+      const internalStore = graph();
+      internalStore.add(
+        sym(uri),
+        sym("https://schema.org/description"),
+        "literal value",
+      );
+
+      const mockSession = {} as unknown as PodOsSession;
+      const store = new Store(mockSession, undefined, undefined, internalStore);
+
+      // and a Thing
+      const subscriber = jest.fn();
+      const thing = new Thing(uri, store);
+
+      // and a subscription to changes of label
+      const observable = thing.observeDescription();
+      observable.subscribe(subscriber);
+
+      expect(subscriber).toHaveBeenCalledTimes(1);
+      expect(subscriber.mock.calls).toEqual([["literal value"]]);
+    });
+
+    it("is undefined if nothing is found in store", () => {
+      const thing = new Thing(
+        "https://jane.doe.example/container/file.ttl#fragment",
+        store,
+      );
+      const subscriber = jest.fn();
+      const observable = thing.observeDescription();
+      observable.subscribe(subscriber);
+
+      expect(subscriber).toHaveBeenCalledTimes(1);
+      expect(subscriber.mock.lastCall).toEqual([undefined]);
+    });
+
+    it.each([
+      "http://purl.org/dc/terms/description",
+      "http://purl.org/dc/elements/1.1/description",
+      "http://schema.org/description",
+      "https://schema.org/description",
+      "https://schema.org/text",
+      "http://www.w3.org/2000/01/rdf-schema#comment",
+      "https://www.w3.org/ns/activitystreams#summary",
+      "https://www.w3.org/ns/activitystreams#content",
+      "http://www.w3.org/2006/vcard/ns#note",
+    ])("returns the literal value of predicate %s", (predicate: string) => {
+      const uri = "https://jane.doe.example/container/file.ttl#fragment";
+      internalStore.add(sym(uri), sym(predicate), "literal value");
+      const thing = new Thing(
+        "https://jane.doe.example/container/file.ttl#fragment",
+        store,
+      );
+      const subscriber = jest.fn();
+      const observable = thing.observeDescription();
+      observable.subscribe(subscriber);
+      expect(subscriber.mock.lastCall).toEqual(["literal value"]);
+    });
+
+    describe("follows observeAnyValue behaviour", () => {
+      jest.useFakeTimers();
+
+      let subscriber: jest.Mock;
+
+      beforeEach(() => {
+        // Given a store with a URI with a description
+        internalStore.add(
+          quad(
+            sym(uri),
+            sym("https://schema.org/description"),
+            literal("literal value"),
+          ),
+        );
+
+        // and a Thing with a subscription to changes in description
+        subscriber = jest.fn();
+        const thing = new Thing(uri, store);
+        const observable = thing.observeDescription();
+        observable.subscribe(subscriber);
+      });
+
+      it("does not push if a description already exists", () => {
+        internalStore.add(
+          sym(uri),
+          sym("https://schema.org/description"),
+          "literal value 2",
+        );
+        jest.advanceTimersByTime(250);
+        expect(subscriber).toHaveBeenCalledTimes(1);
+      });
+
+      it("pushes on remove", () => {
+        internalStore.removeStatement(
+          quad(
+            sym(uri),
+            sym("https://schema.org/description"),
+            literal("literal value"),
+          ),
+        );
+        jest.advanceTimersByTime(250);
+        expect(subscriber).toHaveBeenCalledTimes(2);
+        expect(subscriber.mock.lastCall).toEqual([undefined]);
+      });
+
+      it("pushes in a group when description changes", () => {
+        internalStore.removeStatement(
+          quad(
+            sym(uri),
+            sym("https://schema.org/description"),
+            literal("literal value"),
+          ),
+        );
+        internalStore.add(
+          sym(uri),
+          sym("https://schema.org/description"),
+          "literal value 2",
+        );
+        jest.advanceTimersByTime(250);
+        expect(subscriber).toHaveBeenCalledTimes(2);
+        expect(subscriber.mock.lastCall).toEqual(["literal value 2"]);
+      });
     });
   });
 });

--- a/core/src/thing/Thing.label.spec.ts
+++ b/core/src/thing/Thing.label.spec.ts
@@ -124,5 +124,36 @@ describe("Thing", function () {
 
       expect(subscriber.mock.lastCall).toEqual([thing.label()]);
     });
+
+    it.each([
+      "http://xmlns.com/foaf/0.1/nick",
+      "http://purl.org/dc/terms/title",
+      "http://purl.org/dc/elements/1.1/title",
+      "http://xmlns.com/foaf/0.1/name",
+      "http://schema.org/name",
+      "https://schema.org/name",
+      "http://www.w3.org/2000/01/rdf-schema#label",
+      "https://www.w3.org/ns/activitystreams#name",
+      "http://www.w3.org/2006/vcard/ns#fn",
+      "http://schema.org/caption",
+      "https://schema.org/caption",
+    ])("returns the literal value of predicate %s", (predicate: string) => {
+      // Given a store with label for a URI using this predicate
+      const internalStore = graph();
+      internalStore.add(sym(uri), sym(predicate), "literal value");
+      const mockSession = {} as unknown as PodOsSession;
+      const store = new Store(mockSession, undefined, undefined, internalStore);
+
+      // and a Thing
+      const subscriber = jest.fn();
+      const thing = new Thing(uri, store);
+
+      // and a subscription to changes of label
+      const observable = thing.observeLabel();
+      observable.subscribe(subscriber);
+
+      expect(subscriber).toHaveBeenCalledTimes(1);
+      expect(subscriber.mock.calls).toEqual([["literal value"]]);
+    });
   });
 });

--- a/core/src/thing/Thing.label.spec.ts
+++ b/core/src/thing/Thing.label.spec.ts
@@ -81,4 +81,48 @@ describe("Thing", function () {
       expect(result).toEqual("literal value");
     });
   });
+
+  describe("observeLabel", () => {
+    const uri = "https://jane.doe.example/container/file.ttl#fragment";
+
+    it("pushes existing value immediately", () => {
+      // Given a store with statements about a URI
+      const internalStore = graph();
+      internalStore.add(
+        sym(uri),
+        sym("http://www.w3.org/2000/01/rdf-schema#label"),
+        "literal value",
+      );
+
+      const mockSession = {} as unknown as PodOsSession;
+      const store = new Store(mockSession, undefined, undefined, internalStore);
+
+      // and a Thing
+      const subscriber = jest.fn();
+      const thing = new Thing(uri, store);
+
+      // and a subscription to changes of label
+      const observable = thing.observeLabel();
+      observable.subscribe(subscriber);
+
+      expect(subscriber).toHaveBeenCalledTimes(1);
+      expect(subscriber.mock.calls).toEqual([["literal value"]]);
+    });
+
+    it("uses same value as label() when nothing is present in store", () => {
+      // Given an empty store
+      const mockSession = {} as unknown as PodOsSession;
+      const store = new Store(mockSession);
+
+      // and a Thing
+      const subscriber = jest.fn();
+      const thing = new Thing(uri, store);
+
+      // and a subscription to changes of label
+      const observable = thing.observeLabel();
+      observable.subscribe(subscriber);
+
+      expect(subscriber.mock.lastCall).toEqual([thing.label()]);
+    });
+  });
 });

--- a/core/src/thing/Thing.ts
+++ b/core/src/thing/Thing.ts
@@ -15,9 +15,8 @@ import {
   merge,
   Observable,
   startWith,
-  skipUntil,
+  switchMap,
   take,
-  repeat,
 } from "rxjs";
 
 export interface Literal {
@@ -256,11 +255,16 @@ export class Thing {
     );
 
     // Watch for additions, but only after a removal (optimization: ignore additions when value exists)
-    const addition$ = relevantChanges$(this.store.additions$).pipe(
-      skipUntil(removalOrInitial$),
-      take(1),
-      map((quad) => ({ type: "addition" as const, value: quad.object.value })),
-      repeat(),
+    const addition$ = removalOrInitial$.pipe(
+      switchMap(() =>
+        relevantChanges$(this.store.additions$).pipe(
+          take(1),
+          map((quad) => ({
+            type: "addition" as const,
+            value: quad.object.value,
+          })),
+        ),
+      ),
     );
 
     return merge(removalOrInitial$, addition$).pipe(

--- a/core/src/thing/Thing.ts
+++ b/core/src/thing/Thing.ts
@@ -229,8 +229,15 @@ export class Thing {
           predicateUris.includes(quad.predicate.value),
       ),
     );
+
+    const currentValue = this.anyValue(...predicateUris);
+    const dirty$ =
+      typeof currentValue === "undefined"
+        ? removal$.pipe(startWith(undefined))
+        : removal$;
+
     const addition$ = this.store.additions$.pipe(
-      skipUntil(removal$),
+      skipUntil(dirty$),
       filter(
         (quad) =>
           quad.subject.value == this.uri &&
@@ -239,12 +246,12 @@ export class Thing {
       take(1),
       map((quad) => quad.object.value),
     );
-    return merge(removal$, addition$).pipe(
+    return merge(dirty$, addition$).pipe(
       debounceTime(250),
       map((value) =>
         typeof value === "string" ? value : this.anyValue(...predicateUris),
       ),
-      startWith(this.anyValue(...predicateUris)),
+      startWith(currentValue),
     );
   }
 

--- a/core/src/thing/Thing.ts
+++ b/core/src/thing/Thing.ts
@@ -42,6 +42,38 @@ export interface Attachment {
   label: string;
 }
 
+/**
+ * Predicate URIs used to identify label values across multiple vocabularies
+ */
+const LABEL_PREDICATES = [
+  "http://www.w3.org/2006/vcard/ns#fn",
+  "http://xmlns.com/foaf/0.1/name",
+  "http://xmlns.com/foaf/0.1/nick",
+  "https://schema.org/name",
+  "http://schema.org/name",
+  "http://purl.org/dc/terms/title",
+  "http://purl.org/dc/elements/1.1/title",
+  "http://www.w3.org/2000/01/rdf-schema#label",
+  "https://www.w3.org/ns/activitystreams#name",
+  "http://schema.org/caption",
+  "https://schema.org/caption",
+];
+
+/**
+ * Predicate URIs used to identify description values across multiple vocabularies
+ */
+const DESCRIPTION_PREDICATES = [
+  "http://purl.org/dc/terms/description",
+  "http://purl.org/dc/elements/1.1/description",
+  "http://schema.org/description",
+  "https://schema.org/description",
+  "https://schema.org/text",
+  "http://www.w3.org/2000/01/rdf-schema#comment",
+  "https://www.w3.org/ns/activitystreams#summary",
+  "https://www.w3.org/ns/activitystreams#content",
+  "http://www.w3.org/2006/vcard/ns#note",
+];
+
 export class Thing {
   readonly uri: string;
   readonly store: Store;
@@ -63,19 +95,7 @@ export class Thing {
    * If no such term is present, it will derive a label from the URI.
    */
   label() {
-    const value = this.anyValue(
-      "http://www.w3.org/2006/vcard/ns#fn",
-      "http://xmlns.com/foaf/0.1/name",
-      "http://xmlns.com/foaf/0.1/nick",
-      "https://schema.org/name",
-      "http://schema.org/name",
-      "http://purl.org/dc/terms/title",
-      "http://purl.org/dc/elements/1.1/title",
-      "http://www.w3.org/2000/01/rdf-schema#label",
-      "https://www.w3.org/ns/activitystreams#name",
-      "http://schema.org/caption",
-      "https://schema.org/caption",
-    );
+    const value = this.anyValue(...LABEL_PREDICATES);
     if (value) {
       return value;
     }
@@ -86,19 +106,9 @@ export class Thing {
    * Observe changes in human-readable label for this thing. See `label`.
    */
   observeLabel() {
-    return this.observeAnyValue(
-      "http://www.w3.org/2006/vcard/ns#fn",
-      "http://xmlns.com/foaf/0.1/name",
-      "http://xmlns.com/foaf/0.1/nick",
-      "https://schema.org/name",
-      "http://schema.org/name",
-      "http://purl.org/dc/terms/title",
-      "http://purl.org/dc/elements/1.1/title",
-      "http://www.w3.org/2000/01/rdf-schema#label",
-      "https://www.w3.org/ns/activitystreams#name",
-      "http://schema.org/caption",
-      "https://schema.org/caption",
-    ).pipe(map((value) => value ?? labelFromUri(this.uri)));
+    return this.observeAnyValue(...LABEL_PREDICATES).pipe(
+      map((value) => value ?? labelFromUri(this.uri)),
+    );
   }
 
   /**
@@ -270,34 +280,14 @@ export class Thing {
    * used for descriptions, like `dct:description`, `schema:description` or `rdfs:comment`
    */
   description() {
-    return this.anyValue(
-      "http://purl.org/dc/terms/description",
-      "http://purl.org/dc/elements/1.1/description",
-      "http://schema.org/description",
-      "https://schema.org/description",
-      "https://schema.org/text",
-      "http://www.w3.org/2000/01/rdf-schema#comment",
-      "https://www.w3.org/ns/activitystreams#summary",
-      "https://www.w3.org/ns/activitystreams#content",
-      "http://www.w3.org/2006/vcard/ns#note",
-    );
+    return this.anyValue(...DESCRIPTION_PREDICATES);
   }
 
   /**
    * Observe changes in literal values that describe this thing. See `description`
    */
   observeDescription() {
-    return this.observeAnyValue(
-      "http://purl.org/dc/terms/description",
-      "http://purl.org/dc/elements/1.1/description",
-      "http://schema.org/description",
-      "https://schema.org/description",
-      "https://schema.org/text",
-      "http://www.w3.org/2000/01/rdf-schema#comment",
-      "https://www.w3.org/ns/activitystreams#summary",
-      "https://www.w3.org/ns/activitystreams#content",
-      "http://www.w3.org/2006/vcard/ns#note",
-    );
+    return this.observeAnyValue(...DESCRIPTION_PREDICATES);
   }
 
   /**

--- a/core/src/thing/Thing.ts
+++ b/core/src/thing/Thing.ts
@@ -81,6 +81,25 @@ export class Thing {
   }
 
   /**
+   * Observe changes in human-readable label for this thing. See `label`.
+   */
+  observeLabel() {
+    return this.observeAnyValue(
+      "http://www.w3.org/2006/vcard/ns#fn",
+      "http://xmlns.com/foaf/0.1/name",
+      "http://xmlns.com/foaf/0.1/nick",
+      "https://schema.org/name",
+      "http://schema.org/name",
+      "http://purl.org/dc/terms/title",
+      "http://purl.org/dc/elements/1.1/title",
+      "http://www.w3.org/2000/01/rdf-schema#label",
+      "https://www.w3.org/ns/activitystreams#name",
+      "http://schema.org/caption",
+      "https://schema.org/caption",
+    ).pipe(map((value) => value ?? labelFromUri(this.uri)));
+  }
+
+  /**
    * Returns all the literal values that are linked to this thing
    */
   literals(): Literal[] {

--- a/core/src/thing/Thing.ts
+++ b/core/src/thing/Thing.ts
@@ -14,6 +14,8 @@ import {
   merge,
   Observable,
   startWith,
+  skipUntil,
+  take,
 } from "rxjs";
 
 export interface Literal {
@@ -191,6 +193,40 @@ export class Thing {
       return Boolean(value);
     });
     return value;
+  }
+
+  /**
+   * Observe changes in a value linked from this thing via one of the given predicates
+   *
+   * Note that return value may differ from that from `anyValue` when more than one value is present.
+   *
+   * @param predicateUris
+   */
+  observeAnyValue(...predicateUris: string[]) {
+    const removal$ = this.store.removals$.pipe(
+      filter(
+        (quad) =>
+          quad.subject.value == this.uri &&
+          predicateUris.includes(quad.predicate.value),
+      ),
+    );
+    const addition$ = this.store.additions$.pipe(
+      skipUntil(removal$),
+      filter(
+        (quad) =>
+          quad.subject.value == this.uri &&
+          predicateUris.includes(quad.predicate.value),
+      ),
+      take(1),
+      map((quad) => quad.object.value),
+    );
+    return merge(removal$, addition$).pipe(
+      debounceTime(250),
+      map((value) =>
+        typeof value === "string" ? value : this.anyValue(...predicateUris),
+      ),
+      startWith(this.anyValue(...predicateUris)),
+    );
   }
 
   /**

--- a/core/src/thing/Thing.ts
+++ b/core/src/thing/Thing.ts
@@ -267,6 +267,23 @@ export class Thing {
   }
 
   /**
+   * Observe changes in literal values that describe this thing. See `description`
+   */
+  observeDescription() {
+    return this.observeAnyValue(
+      "http://purl.org/dc/terms/description",
+      "http://purl.org/dc/elements/1.1/description",
+      "http://schema.org/description",
+      "https://schema.org/description",
+      "https://schema.org/text",
+      "http://www.w3.org/2000/01/rdf-schema#comment",
+      "https://www.w3.org/ns/activitystreams#summary",
+      "https://www.w3.org/ns/activitystreams#content",
+      "http://www.w3.org/2006/vcard/ns#note",
+    );
+  }
+
+  /**
    * Returns the url of a picture or logo associated with this thing
    * Tries to match common RDF terms used for pictures like `schema:image`,
    * `vcard:photo` or `foaf:img`

--- a/core/src/thing/Thing.ts
+++ b/core/src/thing/Thing.ts
@@ -10,6 +10,7 @@ import {
   debounceTime,
   distinctUntilChanged,
   filter,
+  identity,
   map,
   merge,
   Observable,
@@ -223,35 +224,42 @@ export class Thing {
    * @param predicateUris
    */
   observeAnyValue(...predicateUris: string[]) {
-    const removal$ = this.store.removals$.pipe(
-      filter(
-        (quad) =>
-          quad.subject.value == this.uri &&
-          predicateUris.includes(quad.predicate.value),
-      ),
+    const currentValue = this.anyValue(...predicateUris);
+
+    const relevantChanges$ = (
+      observable: typeof this.store.removals$ | typeof this.store.additions$,
+    ) =>
+      observable.pipe(
+        filter(
+          (quad) =>
+            quad.subject.value === this.uri &&
+            predicateUris.includes(quad.predicate.value),
+        ),
+      );
+
+    // All removals + initial signal if no value exists
+    const removalOrInitial$ = relevantChanges$(this.store.removals$).pipe(
+      map(() => ({ type: "removal" as const })),
+      currentValue === undefined
+        ? startWith({ type: "removal" as const })
+        : identity,
     );
 
-    const currentValue = this.anyValue(...predicateUris);
-    const dirty$ =
-      typeof currentValue === "undefined"
-        ? removal$.pipe(startWith(undefined))
-        : removal$;
-
-    const addition$ = this.store.additions$.pipe(
-      skipUntil(dirty$),
-      filter(
-        (quad) =>
-          quad.subject.value == this.uri &&
-          predicateUris.includes(quad.predicate.value),
-      ),
+    // Watch for additions, but only after a removal (optimization: ignore additions when value exists)
+    const addition$ = relevantChanges$(this.store.additions$).pipe(
+      skipUntil(removalOrInitial$),
       take(1),
-      map((quad) => quad.object.value),
+      map((quad) => ({ type: "addition" as const, value: quad.object.value })),
       repeat(),
     );
-    return merge(dirty$, addition$).pipe(
+
+    return merge(removalOrInitial$, addition$).pipe(
       debounceTime(250),
-      map((value) =>
-        typeof value === "string" ? value : this.anyValue(...predicateUris),
+      map(
+        (event) =>
+          event.type === "addition"
+            ? event.value // use the value that was added
+            : this.anyValue(...predicateUris), // determine a new value after a removal
       ),
       startWith(currentValue),
     );

--- a/core/src/thing/Thing.ts
+++ b/core/src/thing/Thing.ts
@@ -16,6 +16,7 @@ import {
   startWith,
   skipUntil,
   take,
+  repeat,
 } from "rxjs";
 
 export interface Literal {
@@ -245,6 +246,7 @@ export class Thing {
       ),
       take(1),
       map((quad) => quad.object.value),
+      repeat(),
     );
     return merge(dirty$, addition$).pipe(
       debounceTime(250),

--- a/docs/elements/components/pos-add-literal-value/readme.md
+++ b/docs/elements/components/pos-add-literal-value/readme.md
@@ -7,12 +7,12 @@
 
 ## Events
 
-| Event                        | Description                                                                                  | Type               |
-| ---------------------------- | -------------------------------------------------------------------------------------------- | ------------------ |
-| `pod-os:added-literal-value` | The entered literal value has been added to the resource and successfully stored to the Pod. | `CustomEvent<any>` |
-| `pod-os:error`               | Something went wrong while adding the literal value.                                         | `CustomEvent<any>` |
-| `pod-os:init`                |                                                                                              | `CustomEvent<any>` |
-| `pod-os:resource`            |                                                                                              | `CustomEvent<any>` |
+| Event                        | Description                                                                                  | Type                   |
+| ---------------------------- | -------------------------------------------------------------------------------------------- | ---------------------- |
+| `pod-os:added-literal-value` | The entered literal value has been added to the resource and successfully stored to the Pod. | `CustomEvent<Literal>` |
+| `pod-os:error`               | Something went wrong while adding the literal value.                                         | `CustomEvent<any>`     |
+| `pod-os:init`                |                                                                                              | `CustomEvent<any>`     |
+| `pod-os:resource`            |                                                                                              | `CustomEvent<any>`     |
 
 
 ## Dependencies

--- a/docs/elements/components/pos-add-relation/readme.md
+++ b/docs/elements/components/pos-add-relation/readme.md
@@ -7,6 +7,14 @@
 
 Add a new relation from the current resource to another one
 
+## Events
+
+| Event                   | Description                                                                     | Type                    |
+| ----------------------- | ------------------------------------------------------------------------------- | ----------------------- |
+| `pod-os:added-relation` | The relation has been added to the resource and successfully stored to the Pod. | `CustomEvent<Relation>` |
+| `pod-os:error`          | Something went wrong while adding the relation.                                 | `CustomEvent<any>`      |
+
+
 ## Dependencies
 
 ### Used by

--- a/docs/elements/components/pos-description/readme.md
+++ b/docs/elements/components/pos-description/readme.md
@@ -5,6 +5,12 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+Displays a description of the resource, as provided by [Thing.description()](https://pod-os.org/reference/core/classes/thing/#description).
+
+Re-renders when data in the store changes using [Thing.observeDescription()](https://pod-os.org/reference/core/classes/thing/#observeDescription).
+
 ## Events
 
 | Event             | Description | Type               |

--- a/docs/elements/components/pos-label/readme.md
+++ b/docs/elements/components/pos-label/readme.md
@@ -7,7 +7,9 @@
 
 ## Overview
 
-Displays a human-readable label of the resource, provided by [Thing.label()](https://pod-os.org/reference/core/classes/thing/#label)
+Displays a human-readable label of the resource, as provided by [Thing.label()](https://pod-os.org/reference/core/classes/thing/#label).
+
+Re-renders when data in the store changes using [Thing.observeLabel()](https://pod-os.org/reference/core/classes/thing/#observeLabel).
 
 ## Events
 

--- a/docs/elements/components/pos-select-term/readme.md
+++ b/docs/elements/components/pos-select-term/readme.md
@@ -15,10 +15,10 @@
 
 ## Events
 
-| Event                  | Description                              | Type               |
-| ---------------------- | ---------------------------------------- | ------------------ |
-| `pod-os:init`          |                                          | `CustomEvent<any>` |
-| `pod-os:term-selected` | Fires when a term is entered or selected | `CustomEvent<any>` |
+| Event                  | Description                              | Type                            |
+| ---------------------- | ---------------------------------------- | ------------------------------- |
+| `pod-os:init`          |                                          | `CustomEvent<any>`              |
+| `pod-os:term-selected` | Fires when a term is entered or selected | `CustomEvent<{ uri: string; }>` |
 
 
 ## Shadow Parts

--- a/docs/elements/components/pos-value/readme.md
+++ b/docs/elements/components/pos-value/readme.md
@@ -8,7 +8,8 @@
 ## Overview
 
 Shows a single value linked to the resource using the given predicate.
-The value is determined by [Thing.anyValue()](https://pod-os.org/reference/core/classes/thing/#anyvalue)
+The value is determined by [Thing.observeAnyValue()](https://pod-os.org/reference/core/classes/thing/#observeanyvalue)
+and re-renders when data in the store changes
 
 ## Properties
 

--- a/elements/CHANGELOG.md
+++ b/elements/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.42.0
+
+### Changed
+
+- [pos-value](https://pod-os.org/reference/elements/components/pos-value/), [pos-label](https://pod-os.org/reference/elements/components/pos-label/) and [pos-description](https://pod-os.org/reference/elements/components/pos-description/): update reactively when data in store changes
+
 ## 0.41.0
 
 ### Changed

--- a/elements/src/components.d.ts
+++ b/elements/src/components.d.ts
@@ -99,6 +99,10 @@ export namespace Components {
         "container": LdpContainer;
         "type": 'file' | 'folder';
     }
+    /**
+     * Displays a description of the resource, as provided by [Thing.description()](https://pod-os.org/reference/core/classes/thing/#description).
+     * Re-renders when data in the store changes using [Thing.observeDescription()](https://pod-os.org/reference/core/classes/thing/#observeDescription).
+     */
     interface PosDescription {
     }
     /**
@@ -139,7 +143,8 @@ export namespace Components {
         "uri": string;
     }
     /**
-     * Displays a human-readable label of the resource, provided by [Thing.label()](https://pod-os.org/reference/core/classes/thing/#label)
+     * Displays a human-readable label of the resource, as provided by [Thing.label()](https://pod-os.org/reference/core/classes/thing/#label).
+     * Re-renders when data in the store changes using [Thing.observeLabel()](https://pod-os.org/reference/core/classes/thing/#observeLabel).
      */
     interface PosLabel {
     }
@@ -360,7 +365,8 @@ export namespace Components {
     }
     /**
      * Shows a single value linked to the resource using the given predicate.
-     * The value is determined by [Thing.anyValue()](https://pod-os.org/reference/core/classes/thing/#anyvalue)
+     * The value is determined by [Thing.observeAnyValue()](https://pod-os.org/reference/core/classes/thing/#observeanyvalue)
+     * and re-renders when data in the store changes
      */
     interface PosValue {
         /**
@@ -749,6 +755,10 @@ declare global {
     interface HTMLPosDescriptionElementEventMap {
         "pod-os:resource": any;
     }
+    /**
+     * Displays a description of the resource, as provided by [Thing.description()](https://pod-os.org/reference/core/classes/thing/#description).
+     * Re-renders when data in the store changes using [Thing.observeDescription()](https://pod-os.org/reference/core/classes/thing/#observeDescription).
+     */
     interface HTMLPosDescriptionElement extends Components.PosDescription, HTMLStencilElement {
         addEventListener<K extends keyof HTMLPosDescriptionElementEventMap>(type: K, listener: (this: HTMLPosDescriptionElement, ev: PosDescriptionCustomEvent<HTMLPosDescriptionElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
         addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
@@ -853,7 +863,8 @@ declare global {
         "pod-os:resource": any;
     }
     /**
-     * Displays a human-readable label of the resource, provided by [Thing.label()](https://pod-os.org/reference/core/classes/thing/#label)
+     * Displays a human-readable label of the resource, as provided by [Thing.label()](https://pod-os.org/reference/core/classes/thing/#label).
+     * Re-renders when data in the store changes using [Thing.observeLabel()](https://pod-os.org/reference/core/classes/thing/#observeLabel).
      */
     interface HTMLPosLabelElement extends Components.PosLabel, HTMLStencilElement {
         addEventListener<K extends keyof HTMLPosLabelElementEventMap>(type: K, listener: (this: HTMLPosLabelElement, ev: PosLabelCustomEvent<HTMLPosLabelElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -1341,7 +1352,8 @@ declare global {
     }
     /**
      * Shows a single value linked to the resource using the given predicate.
-     * The value is determined by [Thing.anyValue()](https://pod-os.org/reference/core/classes/thing/#anyvalue)
+     * The value is determined by [Thing.observeAnyValue()](https://pod-os.org/reference/core/classes/thing/#observeanyvalue)
+     * and re-renders when data in the store changes
      */
     interface HTMLPosValueElement extends Components.PosValue, HTMLStencilElement {
         addEventListener<K extends keyof HTMLPosValueElementEventMap>(type: K, listener: (this: HTMLPosValueElement, ev: PosValueCustomEvent<HTMLPosValueElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -1539,6 +1551,10 @@ declare namespace LocalJSX {
         "onPod-os:link"?: (event: PosCreateNewContainerItemCustomEvent<string>) => void;
         "type": 'file' | 'folder';
     }
+    /**
+     * Displays a description of the resource, as provided by [Thing.description()](https://pod-os.org/reference/core/classes/thing/#description).
+     * Re-renders when data in the store changes using [Thing.observeDescription()](https://pod-os.org/reference/core/classes/thing/#observeDescription).
+     */
     interface PosDescription {
         "onPod-os:resource"?: (event: PosDescriptionCustomEvent<any>) => void;
     }
@@ -1593,7 +1609,8 @@ declare namespace LocalJSX {
         "uri"?: string;
     }
     /**
-     * Displays a human-readable label of the resource, provided by [Thing.label()](https://pod-os.org/reference/core/classes/thing/#label)
+     * Displays a human-readable label of the resource, as provided by [Thing.label()](https://pod-os.org/reference/core/classes/thing/#label).
+     * Re-renders when data in the store changes using [Thing.observeLabel()](https://pod-os.org/reference/core/classes/thing/#observeLabel).
      */
     interface PosLabel {
         "onPod-os:resource"?: (event: PosLabelCustomEvent<any>) => void;
@@ -1855,7 +1872,8 @@ declare namespace LocalJSX {
     }
     /**
      * Shows a single value linked to the resource using the given predicate.
-     * The value is determined by [Thing.anyValue()](https://pod-os.org/reference/core/classes/thing/#anyvalue)
+     * The value is determined by [Thing.observeAnyValue()](https://pod-os.org/reference/core/classes/thing/#observeanyvalue)
+     * and re-renders when data in the store changes
      */
     interface PosValue {
         "onPod-os:resource"?: (event: PosValueCustomEvent<any>) => void;
@@ -2046,6 +2064,10 @@ declare module "@stencil/core" {
             "pos-container-item": LocalJSX.IntrinsicElements["pos-container-item"] & JSXBase.HTMLAttributes<HTMLPosContainerItemElement>;
             "pos-container-toolbar": LocalJSX.IntrinsicElements["pos-container-toolbar"] & JSXBase.HTMLAttributes<HTMLPosContainerToolbarElement>;
             "pos-create-new-container-item": LocalJSX.IntrinsicElements["pos-create-new-container-item"] & JSXBase.HTMLAttributes<HTMLPosCreateNewContainerItemElement>;
+            /**
+             * Displays a description of the resource, as provided by [Thing.description()](https://pod-os.org/reference/core/classes/thing/#description).
+             * Re-renders when data in the store changes using [Thing.observeDescription()](https://pod-os.org/reference/core/classes/thing/#observeDescription).
+             */
             "pos-description": LocalJSX.IntrinsicElements["pos-description"] & JSXBase.HTMLAttributes<HTMLPosDescriptionElement>;
             /**
              * Styled wrapper around native dialog element, with slots `title` and `content`
@@ -2063,7 +2085,8 @@ declare module "@stencil/core" {
             "pos-image": LocalJSX.IntrinsicElements["pos-image"] & JSXBase.HTMLAttributes<HTMLPosImageElement>;
             "pos-internal-router": LocalJSX.IntrinsicElements["pos-internal-router"] & JSXBase.HTMLAttributes<HTMLPosInternalRouterElement>;
             /**
-             * Displays a human-readable label of the resource, provided by [Thing.label()](https://pod-os.org/reference/core/classes/thing/#label)
+             * Displays a human-readable label of the resource, as provided by [Thing.label()](https://pod-os.org/reference/core/classes/thing/#label).
+             * Re-renders when data in the store changes using [Thing.observeLabel()](https://pod-os.org/reference/core/classes/thing/#observeLabel).
              */
             "pos-label": LocalJSX.IntrinsicElements["pos-label"] & JSXBase.HTMLAttributes<HTMLPosLabelElement>;
             /**
@@ -2141,7 +2164,8 @@ declare module "@stencil/core" {
             "pos-user-menu": LocalJSX.IntrinsicElements["pos-user-menu"] & JSXBase.HTMLAttributes<HTMLPosUserMenuElement>;
             /**
              * Shows a single value linked to the resource using the given predicate.
-             * The value is determined by [Thing.anyValue()](https://pod-os.org/reference/core/classes/thing/#anyvalue)
+             * The value is determined by [Thing.observeAnyValue()](https://pod-os.org/reference/core/classes/thing/#observeanyvalue)
+             * and re-renders when data in the store changes
              */
             "pos-value": LocalJSX.IntrinsicElements["pos-value"] & JSXBase.HTMLAttributes<HTMLPosValueElement>;
         }

--- a/elements/src/components/pos-description/pos-description.spec.tsx
+++ b/elements/src/components/pos-description/pos-description.spec.tsx
@@ -1,5 +1,6 @@
 import { newSpecPage } from '@stencil/core/testing';
 import { PosDescription } from './pos-description';
+import { Subject } from 'rxjs';
 
 describe('pos-description', () => {
   it('is empty initially', async () => {
@@ -19,13 +20,44 @@ describe('pos-description', () => {
       components: [PosDescription],
       html: `<pos-description />`,
     });
-    await page.rootInstance.receiveResource({
-      description: () => 'Test Resource',
-    });
+    const observedDescription$ = new Subject<string>();
+    const resource = {
+      observeDescription: () => observedDescription$,
+    };
+    await page.rootInstance.receiveResource(resource);
+    observedDescription$.next('Test Resource');
     await page.waitForChanges();
     expect(page.root).toEqualHtml(`
       <pos-description>
         <mock:shadow-root>Test Resource</mock:shadow-root>
+      </pos-description>
+  `);
+  });
+
+  it('updates description when changes', async () => {
+    const page = await newSpecPage({
+      components: [PosDescription],
+      html: `<pos-description />`,
+    });
+    const observedDescription$ = new Subject<string>();
+    const resource = {
+      observeDescription: () => observedDescription$,
+    };
+    await page.rootInstance.receiveResource(resource);
+
+    observedDescription$.next('Test Resource');
+    await page.waitForChanges();
+    expect(page.root).toEqualHtml(`
+      <pos-description>
+        <mock:shadow-root>Test Resource</mock:shadow-root>
+      </pos-description>
+  `);
+
+    observedDescription$.next('Test Resource 2');
+    await page.waitForChanges();
+    expect(page.root).toEqualHtml(`
+      <pos-description>
+        <mock:shadow-root>Test Resource 2</mock:shadow-root>
       </pos-description>
   `);
   });

--- a/elements/src/components/pos-description/pos-description.spec.tsx
+++ b/elements/src/components/pos-description/pos-description.spec.tsx
@@ -61,4 +61,55 @@ describe('pos-description', () => {
       </pos-description>
   `);
   });
+
+  it('unsubscribes from previous resource when receiving a new one', async () => {
+    // Given a pos-description component
+    const page = await newSpecPage({
+      components: [PosDescription],
+      html: `<pos-description />`,
+    });
+
+    // And a resource A with observable
+    const descriptionA$ = new Subject<string>();
+    const resourceA = {
+      observeDescription: () => descriptionA$,
+    };
+
+    // And a second resource B with observable
+    const descriptionB$ = new Subject<string>();
+    const resourceB = {
+      observeDescription: () => descriptionB$,
+    };
+
+    // And the resource A and it's description are received
+    await page.rootInstance.receiveResource(resourceA);
+    descriptionA$.next('Description A');
+    await page.waitForChanges();
+    expect(page.root).toEqualHtml(`
+      <pos-description>
+        <mock:shadow-root>Description A</mock:shadow-root>
+      </pos-description>
+  `);
+
+    // But the component changes to the resource B after that
+    await page.rootInstance.receiveResource(resourceB);
+    descriptionB$.next('Description B');
+    await page.waitForChanges();
+    expect(page.root).toEqualHtml(`
+      <pos-description>
+        <mock:shadow-root>Description B</mock:shadow-root>
+      </pos-description>
+  `);
+
+    // When the first resource now gets an update description
+    descriptionA$.next('Description A Updated');
+    await page.waitForChanges();
+
+    // Then the component should not be affected, because it is bound to resource B
+    expect(page.root).toEqualHtml(`
+      <pos-description>
+        <mock:shadow-root>Description B</mock:shadow-root>
+      </pos-description>
+  `);
+  });
 });

--- a/elements/src/components/pos-description/pos-description.tsx
+++ b/elements/src/components/pos-description/pos-description.tsx
@@ -1,25 +1,41 @@
 import { Thing } from '@pod-os/core';
 import { Component, Event, EventEmitter, State } from '@stencil/core';
 import { ResourceAware, subscribeResource } from '../events/ResourceAware';
+import { Subject, takeUntil } from 'rxjs';
 
+/**
+ * Displays a description of the resource, as provided by [Thing.description()](https://pod-os.org/reference/core/classes/thing/#description).
+ *
+ * Re-renders when data in the store changes using [Thing.observeDescription()](https://pod-os.org/reference/core/classes/thing/#observeDescription).
+ */
 @Component({
   tag: 'pos-description',
   shadow: true,
 })
 export class PosDescription implements ResourceAware {
-  @State() resource: Thing;
+  @State() description: string;
 
   @Event({ eventName: 'pod-os:resource' }) subscribeResource: EventEmitter;
+
+  private readonly disconnected$ = new Subject<void>();
 
   componentWillLoad() {
     subscribeResource(this);
   }
 
   receiveResource = (resource: Thing) => {
-    this.resource = resource;
+    resource
+      .observeDescription()
+      .pipe(takeUntil(this.disconnected$))
+      .subscribe(description => (this.description = description));
   };
 
   render() {
-    return this.resource ? this.resource.description() : null;
+    return this.description ? this.description : null;
+  }
+
+  disconnectedCallback() {
+    this.disconnected$.next();
+    this.disconnected$.unsubscribe();
   }
 }

--- a/elements/src/components/pos-description/pos-description.tsx
+++ b/elements/src/components/pos-description/pos-description.tsx
@@ -24,6 +24,7 @@ export class PosDescription implements ResourceAware {
   }
 
   receiveResource = (resource: Thing) => {
+    this.disconnected$.next();
     resource
       .observeDescription()
       .pipe(takeUntil(this.disconnected$))

--- a/elements/src/components/pos-description/pos-description.tsx
+++ b/elements/src/components/pos-description/pos-description.tsx
@@ -36,6 +36,6 @@ export class PosDescription implements ResourceAware {
 
   disconnectedCallback() {
     this.disconnected$.next();
-    this.disconnected$.unsubscribe();
+    this.disconnected$.complete();
   }
 }

--- a/elements/src/components/pos-label/pos-label.spec.tsx
+++ b/elements/src/components/pos-label/pos-label.spec.tsx
@@ -1,5 +1,6 @@
 import { newSpecPage } from '@stencil/core/testing';
 import { PosLabel } from './pos-label';
+import { Subject } from 'rxjs';
 
 describe('pos-label', () => {
   it('is empty initially', async () => {
@@ -19,9 +20,12 @@ describe('pos-label', () => {
       components: [PosLabel],
       html: `<pos-label />`,
     });
-    await page.rootInstance.receiveResource({
-      label: () => 'Test Resource',
-    });
+    const observedLabel$ = new Subject<string>();
+    const resource = {
+      observeLabel: () => observedLabel$,
+    };
+    await page.rootInstance.receiveResource(resource);
+    observedLabel$.next('Test Resource');
     await page.waitForChanges();
     expect(page.root).toEqualHtml(`
       <pos-label>

--- a/elements/src/components/pos-label/pos-label.spec.tsx
+++ b/elements/src/components/pos-label/pos-label.spec.tsx
@@ -33,4 +33,32 @@ describe('pos-label', () => {
       </pos-label>
   `);
   });
+
+  it('updates label when changed', async () => {
+    const page = await newSpecPage({
+      components: [PosLabel],
+      html: `<pos-label />`,
+    });
+    const observedLabel$ = new Subject<string>();
+    const resource = {
+      observeLabel: () => observedLabel$,
+    };
+    await page.rootInstance.receiveResource(resource);
+
+    observedLabel$.next('Test Resource');
+    await page.waitForChanges();
+    expect(page.root).toEqualHtml(`
+      <pos-label>
+        <mock:shadow-root>Test Resource</mock:shadow-root>
+      </pos-label>
+  `);
+
+    observedLabel$.next('Test Resource 2');
+    await page.waitForChanges();
+    expect(page.root).toEqualHtml(`
+      <pos-label>
+        <mock:shadow-root>Test Resource 2</mock:shadow-root>
+      </pos-label>
+  `);
+  });
 });

--- a/elements/src/components/pos-label/pos-label.tsx
+++ b/elements/src/components/pos-label/pos-label.tsx
@@ -1,29 +1,42 @@
 import { Thing } from '@pod-os/core';
 import { Component, Event, State } from '@stencil/core';
 import { ResourceAware, ResourceEventEmitter, subscribeResource } from '../events/ResourceAware';
+import { Subject, takeUntil } from 'rxjs';
 
 /**
- * Displays a human-readable label of the resource, provided by [Thing.label()](https://pod-os.org/reference/core/classes/thing/#label)
+ * Displays a human-readable label of the resource, as provided by [Thing.label()](https://pod-os.org/reference/core/classes/thing/#label).
+ * 
+ * Re-renders when data in the store changes using [Thing.observeLabel()](https://pod-os.org/reference/core/classes/thing/#observeLabel).
  */
 @Component({
   tag: 'pos-label',
   shadow: true,
 })
 export class PosLabel implements ResourceAware {
-  @State() resource: Thing;
+  @State() label: string;
 
   @Event({ eventName: 'pod-os:resource' })
   subscribeResource: ResourceEventEmitter;
+
+  private readonly disconnected$ = new Subject<void>();
 
   componentWillLoad() {
     subscribeResource(this);
   }
 
   receiveResource = (resource: Thing) => {
-    this.resource = resource;
+    resource
+      .observeLabel()
+      .pipe(takeUntil(this.disconnected$))
+      .subscribe(label => (this.label = label));
   };
 
   render() {
-    return this.resource ? this.resource.label() : null;
+    return this.label ? this.label : null;
+  }
+
+  disconnectedCallback() {
+    this.disconnected$.next();
+    this.disconnected$.unsubscribe();
   }
 }

--- a/elements/src/components/pos-label/pos-label.tsx
+++ b/elements/src/components/pos-label/pos-label.tsx
@@ -5,7 +5,7 @@ import { Subject, takeUntil } from 'rxjs';
 
 /**
  * Displays a human-readable label of the resource, as provided by [Thing.label()](https://pod-os.org/reference/core/classes/thing/#label).
- * 
+ *
  * Re-renders when data in the store changes using [Thing.observeLabel()](https://pod-os.org/reference/core/classes/thing/#observeLabel).
  */
 @Component({
@@ -37,6 +37,6 @@ export class PosLabel implements ResourceAware {
 
   disconnectedCallback() {
     this.disconnected$.next();
-    this.disconnected$.unsubscribe();
+    this.disconnected$.complete();
   }
 }

--- a/elements/src/components/pos-list/pos-list.integration.spec.tsx
+++ b/elements/src/components/pos-list/pos-list.integration.spec.tsx
@@ -5,7 +5,7 @@ import { PosLabel } from '../pos-label/pos-label';
 import { PosList } from './pos-list';
 import { PosResource } from '../pos-resource/pos-resource';
 import { when } from 'jest-when';
-import { Subject } from 'rxjs';
+import { ReplaySubject, Subject } from 'rxjs';
 import { Relation, Thing } from '@pod-os/core';
 
 describe('pos-list', () => {
@@ -21,12 +21,16 @@ describe('pos-list', () => {
           } as unknown as Relation,
         ],
       } as unknown as Thing);
+    const observedLabel1$ = new ReplaySubject<string>();
+    observedLabel1$.next('Video 1');
     when(os.store.get)
       .calledWith('https://video.test/video-1')
-      .mockReturnValue({ uri: 'https://video.test/video-1', label: () => 'Video 1' } as unknown as Thing);
+      .mockReturnValue({ uri: 'https://video.test/video-1', observeLabel: () => observedLabel1$ } as unknown as Thing);
+    const observedLabel2$ = new ReplaySubject<string>();
+    observedLabel2$.next('Video 2');
     when(os.store.get)
       .calledWith('https://video.test/video-2')
-      .mockReturnValue({ uri: 'https://video.test/video-2', label: () => 'Video 2' } as unknown as Thing);
+      .mockReturnValue({ uri: 'https://video.test/video-2', observeLabel: () => observedLabel2$ } as unknown as Thing);
     const page = await newSpecPage({
       components: [PosApp, PosLabel, PosList, PosResource],
       supportsShadowDom: false,
@@ -70,15 +74,18 @@ describe('pos-list', () => {
 
   it('children render label for all things of the given type, reactively', async () => {
     const os = mockPodOS();
-    const observed$ = new Subject<string[]>();
-    when(os.store.observeFindMembers).calledWith('http://schema.org/Video').mockReturnValue(observed$);
+    const observedMembers$ = new Subject<string[]>();
+    when(os.store.observeFindMembers).calledWith('http://schema.org/Video').mockReturnValue(observedMembers$);
+    const observedLabel1$ = new ReplaySubject<string>();
+    observedLabel1$.next('Video 1');
     when(os.store.get)
       .calledWith('https://video.test/video-1')
-      .mockReturnValue({ uri: 'https://video.test/video-1', label: () => 'Video 1' } as unknown as Thing);
+      .mockReturnValue({ uri: 'https://video.test/video-1', observeLabel: () => observedLabel1$ } as unknown as Thing);
+    const observedLabel2$ = new ReplaySubject<string>();
+    observedLabel2$.next('Video 2');
     when(os.store.get)
       .calledWith('https://video.test/video-2')
-      .mockReturnValue({ uri: 'https://video.test/video-2', label: () => 'Video 2' } as unknown as Thing);
-
+      .mockReturnValue({ uri: 'https://video.test/video-2', observeLabel: () => observedLabel2$ } as unknown as Thing);
     const page = await newSpecPage({
       components: [PosApp, PosLabel, PosList, PosResource],
       supportsShadowDom: false,
@@ -95,14 +102,14 @@ describe('pos-list', () => {
     let resources = page.root ? page.root.querySelectorAll('pos-list pos-resource') : [];
     expect(resources).toHaveLength(0);
 
-    observed$.next(['https://video.test/video-1']);
+    observedMembers$.next(['https://video.test/video-1']);
     await page.waitForChanges();
     resources = page.root ? page.root.querySelectorAll('pos-list pos-resource') : [];
     expect(resources).toHaveLength(1);
     expect(resources[0].getAttribute('about')).toEqual('https://video.test/video-1');
     expect(resources[0].textContent).toEqual('Video 1');
 
-    observed$.next(['https://video.test/video-1', 'https://video.test/video-2']);
+    observedMembers$.next(['https://video.test/video-1', 'https://video.test/video-2']);
     await page.waitForChanges();
     resources = page.root ? page.root.querySelectorAll('pos-list pos-resource') : [];
     expect(resources).toHaveLength(2);
@@ -111,7 +118,7 @@ describe('pos-list', () => {
     expect(resources[1].getAttribute('about')).toEqual('https://video.test/video-2');
     expect(resources[1].textContent).toEqual('Video 2');
 
-    observed$.next(['https://video.test/video-2']);
+    observedMembers$.next(['https://video.test/video-2']);
     await page.waitForChanges();
     resources = page.root ? page.root.querySelectorAll('pos-list pos-resource') : [];
     expect(resources).toHaveLength(1);

--- a/elements/src/components/pos-resource/pos-resource.integration.spec.tsx
+++ b/elements/src/components/pos-resource/pos-resource.integration.spec.tsx
@@ -5,15 +5,18 @@ import { PosApp } from '../pos-app/pos-app';
 import { PosResource } from './pos-resource';
 import { PosLabel } from '../pos-label/pos-label';
 import { when } from 'jest-when';
+import { ReplaySubject } from 'rxjs';
 
 describe('pos-resource with a pos-label child', () => {
   it('renders label for successfully loaded resource', async () => {
     const os = mockPodOS();
     when(os.fetch).calledWith('https://resource.test').mockReturnValue(Promise.resolve());
+    const observedLabel$ = new ReplaySubject<string>();
+    observedLabel$.next('Test Resource');
     when(os.store.get)
       .calledWith('https://resource.test')
       .mockReturnValue({
-        label: () => 'Test Resource',
+        observeLabel: () => observedLabel$,
       });
     const page = await newSpecPage({
       components: [PosApp, PosResource, PosLabel],
@@ -46,10 +49,12 @@ describe('pos-resource with a pos-label child', () => {
     const loadingPromise = new Promise(resolve => setTimeout(resolve, 1));
     const os = mockPodOS();
     when(os.fetch).calledWith('https://resource.test').mockReturnValue(loadingPromise);
+    const observedLabel$ = new ReplaySubject<string>();
+    observedLabel$.next('Test Resource');
     when(os.store.get)
       .calledWith('https://resource.test')
       .mockReturnValue({
-        label: () => 'Test Resource',
+        observeLabel: () => observedLabel$,
       });
     const page = await newSpecPage({
       components: [PosApp, PosResource, PosLabel],
@@ -159,10 +164,12 @@ describe('pos-resource with a pos-label child', () => {
   it('renders multiple labels for successfully loaded resource', async () => {
     const os = mockPodOS();
     when(os.fetch).calledWith('https://resource.test').mockReturnValue(Promise.resolve());
+    const observedLabel$ = new ReplaySubject<string>();
+    observedLabel$.next('Test Resource');
     when(os.store.get)
       .calledWith('https://resource.test')
       .mockReturnValue({
-        label: () => 'Test Resource',
+        observeLabel: () => observedLabel$,
       });
     const page = await newSpecPage({
       components: [PosApp, PosResource, PosLabel],
@@ -207,10 +214,12 @@ describe('pos-resource with a pos-label child', () => {
     const loadingPromise = new Promise(resolve => setTimeout(resolve, 1));
     const os = mockPodOS();
     when(os.fetch).calledWith('https://resource.test').mockReturnValue(loadingPromise);
+    const observedLabel$ = new ReplaySubject<string>();
+    observedLabel$.next('Test Resource');
     when(os.store.get)
       .calledWith('https://resource.test')
       .mockReturnValue({
-        label: () => 'Test Resource',
+        observeLabel: () => observedLabel$,
       });
     const page = await newSpecPage({
       components: [PosApp, PosResource, PosLabel],
@@ -256,10 +265,12 @@ describe('pos-resource with a pos-label child', () => {
   it('renders label for lazy resource that would fetch to fail', async () => {
     const os = mockPodOS();
     when(os.fetch).calledWith('https://resource.test').mockRejectedValue(new Error('not found'));
+    const observedLabel$ = new ReplaySubject<string>();
+    observedLabel$.next('Test Resource');
     when(os.store.get)
       .calledWith('https://resource.test')
       .mockReturnValue({
-        label: () => 'Test Resource',
+        observeLabel: () => observedLabel$,
       });
     const page = await newSpecPage({
       components: [PosApp, PosResource, PosLabel],
@@ -291,10 +302,12 @@ describe('pos-resource with a pos-label child', () => {
   it('renders error for lazy resource fails when fetched', async () => {
     const os = mockPodOS();
     when(os.fetch).calledWith('https://resource.test').mockRejectedValue(new Error('not found'));
+    const observedLabel$ = new ReplaySubject<string>();
+    observedLabel$.next('Test Resource');
     when(os.store.get)
       .calledWith('https://resource.test')
       .mockReturnValueOnce({
-        label: () => 'Test Resource',
+        observeLabel: () => observedLabel$,
       });
     const page = await newSpecPage({
       components: [PosApp, PosResource, PosLabel],
@@ -344,13 +357,17 @@ describe('pos-resource with a pos-label child', () => {
   it('rerenders child after lazy resource was fetched', async () => {
     const os = mockPodOS();
     when(os.fetch).calledWith('https://resource.test').mockResolvedValue(null);
+    const observedLabel1$ = new ReplaySubject<string>();
+    observedLabel1$.next('Test Resource');
+    const observedLabel2$ = new ReplaySubject<string>();
+    observedLabel2$.next('Updated Test Resource');
     when(os.store.get)
       .calledWith('https://resource.test')
       .mockReturnValueOnce({
-        label: () => 'Test Resource',
+        observeLabel: () => observedLabel1$,
       })
       .mockReturnValueOnce({
-        label: () => 'Updated Test Resource',
+        observeLabel: () => observedLabel2$,
       });
     const page = await newSpecPage({
       components: [PosApp, PosResource, PosLabel],

--- a/elements/src/components/pos-rich-link/pos-rich-link.integration.spec.tsx
+++ b/elements/src/components/pos-rich-link/pos-rich-link.integration.spec.tsx
@@ -6,25 +6,34 @@ import { PosLabel } from '../pos-label/pos-label';
 import { PosResource } from '../pos-resource/pos-resource';
 import { PosRichLink } from './pos-rich-link';
 import { when } from 'jest-when';
+import { ReplaySubject } from 'rxjs';
 
 describe('pos-rich-link', () => {
   let os;
   beforeEach(async () => {
     os = mockPodOS();
+    const observedLabel1$ = new ReplaySubject<string>();
+    observedLabel1$.next('Test label');
+    const observedDescription1$ = new ReplaySubject<string>();
+    observedDescription1$.next('Test description');
     when(os.store.get)
       .calledWith('https://resource.test')
       .mockReturnValue({
         uri: 'https://resource.test',
-        label: () => 'Test label',
-        description: () => 'Test description',
+        observeLabel: () => observedLabel1$,
+        observeDescription: () => observedDescription1$,
         relations: () => [{ predicate: 'https://schema.org/video', uris: ['https://video.test/video-1'] }],
       });
+    const observedLabel2$ = new ReplaySubject<string>();
+    observedLabel2$.next('Video 1');
+    const observedDescription2$ = new ReplaySubject<string>();
+    observedDescription2$.next('Description of Video 1');
     when(os.store.get)
       .calledWith('https://video.test/video-1')
       .mockReturnValue({
         uri: 'https://video.test/video-1',
-        label: () => 'Video 1',
-        description: () => 'Description of Video 1',
+        observeLabel: () => observedLabel2$,
+        observeDescription: () => observedDescription2$,
         reverseRelations: () => [{ predicate: 'https://schema.org/video', uris: ['https://resource.test'] }],
       });
   });

--- a/elements/src/components/pos-switch/pos-switch.integration.spec.tsx
+++ b/elements/src/components/pos-switch/pos-switch.integration.spec.tsx
@@ -8,11 +8,13 @@ import { PosSwitch } from './pos-switch';
 import { PosResource } from '../pos-resource/pos-resource';
 import { when } from 'jest-when';
 import { RdfType, Relation, Thing } from '@pod-os/core';
-import { Subject } from 'rxjs';
+import { ReplaySubject, Subject } from 'rxjs';
 
 describe('pos-switch', () => {
   it('renders template based on properties of resource, reactively', async () => {
     const os = mockPodOS();
+    const observedLabel$ = new ReplaySubject<string>();
+    observedLabel$.next('Recipe 1');
     const observedTypes$ = new Subject<RdfType[]>();
     const observedRelations$ = new Subject<Relation[]>();
     const observedReverseRelations$ = new Subject<Relation[]>();
@@ -20,7 +22,9 @@ describe('pos-switch', () => {
       .calledWith('https://resource.test')
       .mockReturnValue({
         uri: 'https://resource.test',
+        // Label is used by pos-picture, and observeLabel by pos-label
         label: () => 'Recipe 1',
+        observeLabel: () => observedLabel$,
         observeTypes: () => observedTypes$,
         observeRelations: () => observedRelations$,
         observeReverseRelations: () => observedReverseRelations$,

--- a/elements/src/components/pos-value/pos-value.spec.tsx
+++ b/elements/src/components/pos-value/pos-value.spec.tsx
@@ -57,4 +57,62 @@ describe('pos-value', () => {
       </>
   `);
   });
+
+  it('updates when resource changes', async () => {
+    const page = await newSpecPage({
+      components: [PosValue],
+      html: `<pos-value predicate="https://vocab.example/#term" />`,
+    });
+    const observedValue1$ = new ReplaySubject<string>();
+    observedValue1$.next(`value for first resource`);
+    await page.rootInstance.receiveResource({
+      observeAnyValue: (uri: string) => (uri === 'https://vocab.example/#term' ? observedValue1$ : undefined),
+    });
+    await page.waitForChanges();
+    expect(page.root).toEqualHtml(`
+      <pos-value predicate="https://vocab.example/#term" />
+        <mock:shadow-root>value for first resource</mock:shadow-root>
+      </>
+  `);
+    const observedValue2$ = new ReplaySubject<string>();
+    observedValue2$.next(`value for second resource`);
+    await page.rootInstance.receiveResource({
+      observeAnyValue: (uri: string) => (uri === 'https://vocab.example/#term' ? observedValue2$ : undefined),
+    });
+    await page.waitForChanges();
+    expect(page.root).toEqualHtml(`
+      <pos-value predicate="https://vocab.example/#term" />
+        <mock:shadow-root>value for second resource</mock:shadow-root>
+      </>
+  `);
+  });
+
+  it('updates when predicate changes', async () => {
+    const page = await newSpecPage({
+      components: [PosValue],
+      html: `<pos-value predicate="https://vocab.example/#term" />`,
+    });
+    const observedValues: { [key: string]: ReplaySubject<string> } = {
+      'https://vocab.example/#term': new ReplaySubject<string>(),
+      'https://vocab.example/#term2': new ReplaySubject<string>(),
+    };
+    observedValues['https://vocab.example/#term'].next(`value of https://vocab.example/#term`);
+    observedValues['https://vocab.example/#term2'].next(`value of https://vocab.example/#term2`);
+    await page.rootInstance.receiveResource({
+      observeAnyValue: (uri: string) => observedValues[uri],
+    });
+    await page.waitForChanges();
+    expect(page.root).toEqualHtml(`
+      <pos-value predicate="https://vocab.example/#term" />
+        <mock:shadow-root>value of https://vocab.example/#term</mock:shadow-root>
+      </>
+  `);
+    page.rootInstance.predicate = 'https://vocab.example/#term2';
+    await page.waitForChanges();
+    expect(page.root).toEqualHtml(`
+      <pos-value predicate="https://vocab.example/#term2" />
+        <mock:shadow-root>value of https://vocab.example/#term2</mock:shadow-root>
+      </>
+  `);
+  });
 });

--- a/elements/src/components/pos-value/pos-value.spec.tsx
+++ b/elements/src/components/pos-value/pos-value.spec.tsx
@@ -1,5 +1,6 @@
 import { newSpecPage } from '@stencil/core/testing';
 import { PosValue } from './pos-value';
+import { ReplaySubject, Subject } from 'rxjs';
 
 describe('pos-value', () => {
   it('is empty initially', async () => {
@@ -19,13 +20,40 @@ describe('pos-value', () => {
       components: [PosValue],
       html: `<pos-value predicate="https://vocab.example/#term" />`,
     });
+    const observedValue$ = new ReplaySubject<string>();
+    observedValue$.next(`value of https://vocab.example/#term`);
     await page.rootInstance.receiveResource({
-      anyValue: uri => `value of ${uri}`,
+      observeAnyValue: (uri: string) => (uri === 'https://vocab.example/#term' ? observedValue$ : undefined),
     });
     await page.waitForChanges();
     expect(page.root).toEqualHtml(`
       <pos-value predicate="https://vocab.example/#term" />
         <mock:shadow-root>value of https://vocab.example/#term</mock:shadow-root>
+      </>
+  `);
+  });
+
+  it('updates property value when changed', async () => {
+    const page = await newSpecPage({
+      components: [PosValue],
+      html: `<pos-value predicate="https://vocab.example/#term" />`,
+    });
+    const observedValue$ = new Subject<string>();
+    await page.rootInstance.receiveResource({
+      observeAnyValue: (uri: string) => (uri === 'https://vocab.example/#term' ? observedValue$ : undefined),
+    });
+    observedValue$.next(`value of https://vocab.example/#term`);
+    await page.waitForChanges();
+    expect(page.root).toEqualHtml(`
+      <pos-value predicate="https://vocab.example/#term" />
+        <mock:shadow-root>value of https://vocab.example/#term</mock:shadow-root>
+      </>
+  `);
+    observedValue$.next(`new value of https://vocab.example/#term`);
+    await page.waitForChanges();
+    expect(page.root).toEqualHtml(`
+      <pos-value predicate="https://vocab.example/#term" />
+        <mock:shadow-root>new value of https://vocab.example/#term</mock:shadow-root>
       </>
   `);
   });

--- a/elements/src/components/pos-value/pos-value.tsx
+++ b/elements/src/components/pos-value/pos-value.tsx
@@ -1,10 +1,12 @@
 import { Thing } from '@pod-os/core';
 import { Component, Event, Prop, State } from '@stencil/core';
 import { ResourceAware, ResourceEventEmitter, subscribeResource } from '../events/ResourceAware';
+import { Subject, takeUntil } from 'rxjs';
 
 /**
  * Shows a single value linked to the resource using the given predicate.
- * The value is determined by [Thing.anyValue()](https://pod-os.org/reference/core/classes/thing/#anyvalue)
+ * The value is determined by [Thing.observeAnyValue()](https://pod-os.org/reference/core/classes/thing/#observeanyvalue)
+ * and re-renders when data in the store changes
  */
 @Component({
   tag: 'pos-value',
@@ -15,20 +17,30 @@ export class PosValue implements ResourceAware {
    * URI of the predicate to get the value from
    */
   @Prop() predicate: string;
-  @State() resource: Thing;
+  @State() value: string;
 
   @Event({ eventName: 'pod-os:resource' })
   subscribeResource: ResourceEventEmitter;
+
+  private readonly disconnected$ = new Subject<void>();
 
   componentWillLoad() {
     subscribeResource(this);
   }
 
   receiveResource = (resource: Thing) => {
-    this.resource = resource;
+    resource
+      .observeAnyValue(this.predicate)
+      .pipe(takeUntil(this.disconnected$))
+      .subscribe(value => (this.value = value));
   };
 
   render() {
-    return this.resource ? this.resource.anyValue(this.predicate) : null;
+    return this.value ?? null;
+  }
+
+  disconnectedCallback() {
+    this.disconnected$.next();
+    this.disconnected$.complete();
   }
 }

--- a/elements/src/components/pos-value/pos-value.tsx
+++ b/elements/src/components/pos-value/pos-value.tsx
@@ -1,5 +1,5 @@
 import { Thing } from '@pod-os/core';
-import { Component, Event, Prop, State } from '@stencil/core';
+import { Component, Event, Prop, State, Watch } from '@stencil/core';
 import { ResourceAware, ResourceEventEmitter, subscribeResource } from '../events/ResourceAware';
 import { Subject, takeUntil } from 'rxjs';
 
@@ -16,7 +16,8 @@ export class PosValue implements ResourceAware {
   /**
    * URI of the predicate to get the value from
    */
-  @Prop() predicate: string;
+  @Prop({ reflect: true }) predicate: string;
+  @State() resource: Thing;
   @State() value: string;
 
   @Event({ eventName: 'pod-os:resource' })
@@ -29,11 +30,18 @@ export class PosValue implements ResourceAware {
   }
 
   receiveResource = (resource: Thing) => {
-    resource
+    this.resource = resource;
+    this.observeAnyValue();
+  };
+
+  @Watch('predicate')
+  observeAnyValue() {
+    this.disconnected$.next();
+    this.resource
       .observeAnyValue(this.predicate)
       .pipe(takeUntil(this.disconnected$))
       .subscribe(value => (this.value = value));
-  };
+  }
 
   render() {
     return this.value ?? null;

--- a/elements/src/test/mockPodOS.ts
+++ b/elements/src/test/mockPodOS.ts
@@ -14,7 +14,7 @@ jest.mock('../authentication', () => ({
 jest.mock('../components/events/usePodOS');
 
 import { when } from 'jest-when';
-import { BehaviorSubject, EMPTY } from 'rxjs';
+import { BehaviorSubject, EMPTY, ReplaySubject } from 'rxjs';
 import { createPodOS } from '../pod-os';
 import { usePodOS } from '../components/events/usePodOS';
 
@@ -50,10 +50,13 @@ export function mockPodOS(): PodOS {
     proposeAppsFor: jest.fn().mockReturnValue([]),
     addRelation: jest.fn(),
   };
+  const observedLabel$ = new ReplaySubject<string>();
+  observedLabel$.next(alice.name);
   when(os.store.get)
     .calledWith(alice.webId)
     .mockReturnValue({
       label: () => alice.name,
+      observeLabel: () => observedLabel$,
       picture: () => ({
         url: alice.picture,
       }),


### PR DESCRIPTION
Closes #175 

- [x] Observable for anyValue, observing subject+predicates
- [x] Observable for description: wrapper around anyValue
- [x] Observable for label: wrapper around anyValue
- [x] Pos-label uses new observable
- [x] Update unit tests using pos-label and pos-description mocks: 
  - [x] mockPodOs: pos-login
  - [x] pos-list
  - [x] pos-resource
  - [x] pos-rich-link
  - [x] pos-switch
- [x] Pos-description uses new observable
- [x] Pos-value uses `observeAnyValue`
- [x] Tests have been written
  - [x] all new code is covered by unit tests
  - [ ] the happy path of a new feature is covered by an end-to-end test
    - Will implement with dynamic pane feature
  - [x] manual explorative tests have been performed
- [x] all dependencies are updated to the latest patch version at minimum
- [x] the [CI pipeline](https://github.com/pod-os/PodOS/actions) passes
- [x] documentation is up-to-date
    - [x] TSDoc style comments on important functions, properties and events
    - stories for new PodOS elements have been added to [storybook](../../storybook)
      - N/A - no new elements
  - [x] Readme.md files of PodOS elements have been re-generated
  - N/A architectural decisions are documented as an [ADR](../decisions/0000-use-markdown-architectural-decision-records.md)
  - [x] Changelogs are updated according to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)