### PR TITLE
Conditional rendering testing value of object of forward/backward link

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -39,7 +39,7 @@ and this project adheres to
 
 ## 0.28.0
 
-- [`addRelation`](https://pod-os.org/reference/core/classes/podos/#addrelation: A method to add a relation (link) between things
+- [`addRelation`](https://pod-os.org/reference/core/classes/podos/#addrelation): A method to add a relation (link) between things
 
 ## 0.27.0
 

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.32.0
+
+### Added
+
+- [`Thing.observeLiterals`](https://pod-os.org/reference/core/classes/thing/#observeliterals) pushes changes to literals
+
 ## 0.31.0
 
 ### Breaking changes

--- a/core/src/thing/Thing.literals.spec.ts
+++ b/core/src/thing/Thing.literals.spec.ts
@@ -271,5 +271,31 @@ describe("Thing", function () {
         ],
       ]);
     });
+
+    it("updates after additions", () => {
+      internalStore.add(sym(uri), sym("http://vocab.test/first"), "value 1-2");
+      jest.advanceTimersByTime(250);
+      expect(subscriber).toHaveBeenCalledTimes(2);
+      expect(literalsSpy).toHaveBeenCalledTimes(2);
+      expect(subscriber.mock.lastCall).toEqual([
+        [
+          {
+            predicate: "http://vocab.test/first",
+            label: "first",
+            values: ["value 1-1", "value 1-2"],
+          },
+          {
+            predicate: "http://vocab.test/second",
+            label: "second",
+            values: ["value 2-1", "value 2-2"],
+          },
+          {
+            predicate: "http://vocab.test/third",
+            label: "third",
+            values: ["value 3-1"],
+          },
+        ],
+      ]);
+    });
   });
 });

--- a/core/src/thing/Thing.literals.spec.ts
+++ b/core/src/thing/Thing.literals.spec.ts
@@ -343,5 +343,16 @@ describe("Thing", function () {
       expect(subscriber).toHaveBeenCalledTimes(1);
       expect(literalsSpy).toHaveBeenCalledTimes(1);
     });
+
+    it("does not push if literals have not changed", () => {
+      internalStore.add(
+        sym(uri),
+        sym("http://vocab.test/first"),
+        sym("http://not.a.literal/"),
+      );
+      jest.advanceTimersByTime(250);
+      expect(literalsSpy).toHaveBeenCalledTimes(2);
+      expect(subscriber).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/core/src/thing/Thing.literals.spec.ts
+++ b/core/src/thing/Thing.literals.spec.ts
@@ -1,20 +1,21 @@
-import { beforeEach, describe, expect, it } from "vitest";
-import { blankNode, graph, IndexedFormula, sym } from "rdflib";
+import { afterEach, beforeEach, describe, expect, it, Mock, vi } from "vitest";
+import { blankNode, graph, IndexedFormula, literal, quad, sym } from "rdflib";
 import { PodOsSession } from "../authentication";
-import { Thing } from "./Thing";
+import { Literal, Thing } from "./Thing";
 import { Store } from "../Store";
+import { Observable, Subscription } from "rxjs";
 
 describe("Thing", function () {
+  let internalStore: IndexedFormula;
+  const mockSession = {} as unknown as PodOsSession;
+  let store: Store;
+
+  beforeEach(() => {
+    internalStore = graph();
+    store = new Store(mockSession, undefined, undefined, internalStore);
+  });
+
   describe("literals", () => {
-    let internalStore: IndexedFormula;
-    const mockSession = {} as unknown as PodOsSession;
-    let store: Store;
-
-    beforeEach(() => {
-      internalStore = graph();
-      store = new Store(mockSession, undefined, undefined, internalStore);
-    });
-
     it("are empty, if store is empty", () => {
       const it = new Thing(
         "https://jane.doe.example/container/file.ttl#fragment",
@@ -159,6 +160,115 @@ describe("Thing", function () {
           label: "literal",
           values: ["literal value"],
         },
+      ]);
+    });
+  });
+
+  describe("observeLiterals", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    let uri: string,
+      subscriber: Mock,
+      thing: Thing,
+      literalsSpy: Mock,
+      observable: Observable<Literal[]>,
+      subscription: Subscription;
+
+    beforeEach(() => {
+      // Given a store with statements about a URI
+      uri = "https://jane.doe.example/container/file.ttl#fragment";
+      internalStore.add(
+        sym(uri),
+        sym("http://vocab.test/first"),
+        "value 1-1",
+        sym(uri),
+      );
+      internalStore.add(
+        sym(uri),
+        sym("http://vocab.test/second"),
+        "value 2-1",
+        sym(uri),
+      );
+      internalStore.add(
+        sym(uri),
+        sym("http://vocab.test/second"),
+        "value 2-2",
+        sym(uri),
+      );
+      internalStore.add(
+        sym(uri),
+        sym("http://vocab.test/third"),
+        "value 3-1",
+        sym(uri),
+      );
+
+      // and a Thing with a literals method
+      subscriber = vi.fn();
+      thing = new Thing(uri, store);
+      literalsSpy = vi.spyOn(thing, "literals");
+
+      // and a subscription to changes in relations
+      observable = thing.observeLiterals();
+      subscription = observable.subscribe(subscriber);
+    });
+
+    it("pushes existing literals immediately", () => {
+      expect(subscriber).toHaveBeenCalledTimes(1);
+      expect(literalsSpy).toHaveBeenCalledTimes(1);
+      expect(subscriber.mock.calls).toEqual([
+        [
+          [
+            {
+              predicate: "http://vocab.test/first",
+              label: "first",
+              values: ["value 1-1"],
+            },
+            {
+              predicate: "http://vocab.test/second",
+              label: "second",
+              values: ["value 2-1", "value 2-2"],
+            },
+            {
+              predicate: "http://vocab.test/third",
+              label: "third",
+              values: ["value 3-1"],
+            },
+          ],
+        ],
+      ]);
+    });
+
+    it("updates after removals", () => {
+      internalStore.removeStatement(
+        quad(
+          sym(uri),
+          sym("http://vocab.test/first"),
+          literal("value 1-1"),
+          sym(uri),
+        ),
+      );
+      vi.advanceTimersByTime(250);
+      expect(subscriber).toHaveBeenCalledTimes(2);
+      expect(literalsSpy).toHaveBeenCalledTimes(2);
+      expect(subscriber.mock.lastCall).toEqual([
+        [
+          {
+            predicate: "http://vocab.test/second",
+            label: "second",
+            values: ["value 2-1", "value 2-2"],
+          },
+          {
+            predicate: "http://vocab.test/third",
+            label: "third",
+            values: ["value 3-1"],
+          },
+        ],
       ]);
     });
   });

--- a/core/src/thing/Thing.literals.spec.ts
+++ b/core/src/thing/Thing.literals.spec.ts
@@ -297,5 +297,40 @@ describe("Thing", function () {
         ],
       ]);
     });
+
+    it("pushes update in groups", () => {
+      internalStore.removeStatement(
+        quad(
+          sym(uri),
+          sym("http://vocab.test/first"),
+          literal("value 1-1"),
+          sym(uri),
+        ),
+      );
+      internalStore.add(sym(uri), sym("http://vocab.test/first"), "value 1-2");
+      internalStore.add(sym(uri), sym("http://vocab.test/third"), "value 3-2");
+      jest.advanceTimersByTime(250);
+      expect(subscriber).toHaveBeenCalledTimes(2);
+      expect(literalsSpy).toHaveBeenCalledTimes(2);
+      expect(subscriber.mock.lastCall).toEqual([
+        [
+          {
+            predicate: "http://vocab.test/second",
+            label: "second",
+            values: ["value 2-1", "value 2-2"],
+          },
+          {
+            predicate: "http://vocab.test/third",
+            label: "third",
+            values: ["value 3-1", "value 3-2"],
+          },
+          {
+            predicate: "http://vocab.test/first",
+            label: "first",
+            values: ["value 1-2"],
+          },
+        ],
+      ]);
+    });
   });
 });

--- a/core/src/thing/Thing.literals.spec.ts
+++ b/core/src/thing/Thing.literals.spec.ts
@@ -3,7 +3,7 @@ import { blankNode, graph, IndexedFormula, literal, quad, sym } from "rdflib";
 import { PodOsSession } from "../authentication";
 import { Literal, Thing } from "./Thing";
 import { Store } from "../Store";
-import { Observable, Subscription } from "rxjs";
+import { Observable } from "rxjs";
 
 describe("Thing", function () {
   let internalStore: IndexedFormula;
@@ -177,8 +177,7 @@ describe("Thing", function () {
       subscriber: Mock,
       thing: Thing,
       literalsSpy: Mock,
-      observable: Observable<Literal[]>,
-      subscription: Subscription;
+      observable: Observable<Literal[]>;
 
     beforeEach(() => {
       // Given a store with statements about a URI
@@ -215,7 +214,7 @@ describe("Thing", function () {
 
       // and a subscription to changes in relations
       observable = thing.observeLiterals();
-      subscription = observable.subscribe(subscriber);
+      observable.subscribe(subscriber);
     });
 
     it("pushes existing literals immediately", () => {
@@ -274,7 +273,7 @@ describe("Thing", function () {
 
     it("updates after additions", () => {
       internalStore.add(sym(uri), sym("http://vocab.test/first"), "value 1-2");
-      jest.advanceTimersByTime(250);
+      vi.advanceTimersByTime(250);
       expect(subscriber).toHaveBeenCalledTimes(2);
       expect(literalsSpy).toHaveBeenCalledTimes(2);
       expect(subscriber.mock.lastCall).toEqual([
@@ -309,7 +308,7 @@ describe("Thing", function () {
       );
       internalStore.add(sym(uri), sym("http://vocab.test/first"), "value 1-2");
       internalStore.add(sym(uri), sym("http://vocab.test/third"), "value 3-2");
-      jest.advanceTimersByTime(250);
+      vi.advanceTimersByTime(250);
       expect(subscriber).toHaveBeenCalledTimes(2);
       expect(literalsSpy).toHaveBeenCalledTimes(2);
       expect(subscriber.mock.lastCall).toEqual([
@@ -339,7 +338,7 @@ describe("Thing", function () {
         sym("http://vocab.test/first"),
         "value",
       );
-      jest.advanceTimersByTime(250);
+      vi.advanceTimersByTime(250);
       expect(subscriber).toHaveBeenCalledTimes(1);
       expect(literalsSpy).toHaveBeenCalledTimes(1);
     });
@@ -350,7 +349,7 @@ describe("Thing", function () {
         sym("http://vocab.test/first"),
         sym("http://not.a.literal/"),
       );
-      jest.advanceTimersByTime(250);
+      vi.advanceTimersByTime(250);
       expect(literalsSpy).toHaveBeenCalledTimes(2);
       expect(subscriber).toHaveBeenCalledTimes(1);
     });

--- a/core/src/thing/Thing.literals.spec.ts
+++ b/core/src/thing/Thing.literals.spec.ts
@@ -332,5 +332,16 @@ describe("Thing", function () {
         ],
       ]);
     });
+
+    it("ignores irrelevant statements about other resources", () => {
+      internalStore.add(
+        sym("https://other.uri/"),
+        sym("http://vocab.test/first"),
+        "value",
+      );
+      jest.advanceTimersByTime(250);
+      expect(subscriber).toHaveBeenCalledTimes(1);
+      expect(literalsSpy).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/core/src/thing/Thing.ts
+++ b/core/src/thing/Thing.ts
@@ -133,6 +133,16 @@ export class Thing {
       debounceTime(250),
       map(() => this.literals()),
       startWith(this.literals()),
+      distinctUntilChanged(
+        (prev, curr) =>
+          prev.length === curr.length &&
+          prev.every(
+            (rel, i) =>
+              rel.predicate === curr[i].predicate &&
+              rel.values.length === curr[i].values.length &&
+              rel.values.every((val, j) => val === curr[i].values[j]),
+          ),
+      ),
     );
   }
 

--- a/core/src/thing/Thing.ts
+++ b/core/src/thing/Thing.ts
@@ -127,6 +127,13 @@ export class Thing {
     }));
   }
 
+  observeLiterals(): Observable<Literal[]> {
+    return this.store.removals$.pipe(
+      map(() => this.literals()),
+      startWith(this.literals()),
+    );
+  }
+
   /**
    * Returns all the unique links from this thing to other resources. This only includes named nodes and excludes rdf:type relations.
    */

--- a/core/src/thing/Thing.ts
+++ b/core/src/thing/Thing.ts
@@ -5,7 +5,7 @@ import { accumulateValues } from "./accumulateValues";
 import { isRdfType } from "./isRdfType";
 import { labelForType } from "./labelForType";
 import { labelFromUri } from "./labelFromUri";
-import { Store } from "../Store";
+import { Store, type Quad } from "../Store";
 import {
   debounceTime,
   distinctUntilChanged,
@@ -227,7 +227,7 @@ export class Thing {
    * @param args.compare Function that compares previous and current values
    */
   private observeChanges<T>(args: {
-    filterFn: (quad) => boolean;
+    filterFn: (quad: Quad) => boolean;
     observes: () => T;
     compare: (prev: T, curr: T) => boolean;
   }): Observable<T> {

--- a/core/src/thing/Thing.ts
+++ b/core/src/thing/Thing.ts
@@ -129,6 +129,7 @@ export class Thing {
 
   observeLiterals(): Observable<Literal[]> {
     return merge(this.store.additions$, this.store.removals$).pipe(
+      debounceTime(250),
       map(() => this.literals()),
       startWith(this.literals()),
     );

--- a/core/src/thing/Thing.ts
+++ b/core/src/thing/Thing.ts
@@ -128,7 +128,7 @@ export class Thing {
   }
 
   observeLiterals(): Observable<Literal[]> {
-    return this.store.removals$.pipe(
+    return merge(this.store.additions$, this.store.removals$).pipe(
       map(() => this.literals()),
       startWith(this.literals()),
     );

--- a/core/src/thing/Thing.ts
+++ b/core/src/thing/Thing.ts
@@ -127,6 +127,9 @@ export class Thing {
     }));
   }
 
+  /**
+   * Observe changes in literal values linked to this thing
+   */
   observeLiterals(): Observable<Literal[]> {
     return merge(this.store.additions$, this.store.removals$).pipe(
       filter((quad) => quad.subject.value === this.uri),

--- a/core/src/thing/Thing.ts
+++ b/core/src/thing/Thing.ts
@@ -129,6 +129,7 @@ export class Thing {
 
   observeLiterals(): Observable<Literal[]> {
     return merge(this.store.additions$, this.store.removals$).pipe(
+      filter((quad) => quad.subject.value === this.uri),
       debounceTime(250),
       map(() => this.literals()),
       startWith(this.literals()),

--- a/core/src/thing/Thing.ts
+++ b/core/src/thing/Thing.ts
@@ -131,22 +131,17 @@ export class Thing {
    * Observe changes in literal values linked to this thing
    */
   observeLiterals(): Observable<Literal[]> {
-    return merge(this.store.additions$, this.store.removals$).pipe(
-      filter((quad) => quad.subject.value === this.uri),
-      debounceTime(250),
-      map(() => this.literals()),
-      startWith(this.literals()),
-      distinctUntilChanged(
-        (prev, curr) =>
-          prev.length === curr.length &&
-          prev.every(
-            (rel, i) =>
-              rel.predicate === curr[i].predicate &&
-              rel.values.length === curr[i].values.length &&
-              rel.values.every((val, j) => val === curr[i].values[j]),
-          ),
-      ),
-    );
+    return this.observeSubjectChanges<Literal[]>({
+      observes: () => this.literals(),
+      compare: (prev, curr) =>
+        prev.length === curr.length &&
+        prev.every(
+          (rel, i) =>
+            rel.predicate === curr[i].predicate &&
+            rel.values.length === curr[i].values.length &&
+            rel.values.every((val, j) => val === curr[i].values[j]),
+        ),
+    });
   }
 
   /**
@@ -173,22 +168,76 @@ export class Thing {
    * Observe changes in links from this thing to other resources
    */
   observeRelations(predicate?: string): Observable<Relation[]> {
+    return this.observeSubjectChanges<Relation[]>({
+      observes: () => this.relations(predicate),
+      compare: (prev, curr) =>
+        prev.length === curr.length &&
+        prev.every(
+          (rel, i) =>
+            rel.predicate === curr[i].predicate &&
+            rel.uris.length === curr[i].uris.length,
+        ),
+    });
+  }
+
+  /**
+   * Generic observable creator that watches the store for changes
+   * that have this thing as a subject
+   * @param args.observedValue Function that returns the current value to observe
+   * @param args.compare Function that compares previous and current values for distinctUntilChanged
+   */
+  private observeSubjectChanges<T>(args: {
+    observes: () => T;
+    compare: (prev: T, curr: T) => boolean;
+  }): Observable<T> {
+    const { observes, compare } = args;
+    return this.observeChanges({
+      filterFn: (quad) => quad.subject.value === this.uri,
+      observes,
+      compare,
+    });
+  }
+
+  /**
+   * Generic observable creator that watches the store for changes
+   * that have this thing as an object
+   * @param args.observedValue Function that returns the current value to observe
+   * @param args.compare Function that compares previous and current values for distinctUntilChanged
+   */
+  private observeObjectChanges<T>(args: {
+    observes: () => T;
+    compare: (prev: T, curr: T) => boolean;
+  }): Observable<T> {
+    const { observes, compare } = args;
+    return this.observeChanges({
+      filterFn: (quad) => quad.object.value === this.uri,
+      observes,
+      compare,
+    });
+  }
+
+  /**
+   * Generic observable creator that watches the store for changes
+   * that match the given filter function before comparing values of this thing for possible changes.
+   * The observable only emits a new value if relevant quads are added or removed, and in consequence
+   * the observed value changes according to the compare function
+   *
+   * @param args.filterFn Filter for relevant quads
+   * @param args.observedValue Function that returns the value to observe
+   * @param args.compare Function that compares previous and current values
+   */
+  private observeChanges<T>(args: {
+    filterFn: (quad) => boolean;
+    observes: () => T;
+    compare: (prev: T, curr: T) => boolean;
+  }): Observable<T> {
+    const { observes, compare, filterFn } = args;
     return merge(this.store.additions$, this.store.removals$).pipe(
-      // Note: we assume that cost of filtering by the optional predicate is not worthwhile
-      filter((quad) => quad.subject.value === this.uri),
+      filter(filterFn),
       debounceTime(250),
-      map(() => this.relations(predicate)),
-      startWith(this.relations(predicate)),
-      // Note: label is constructed from predicate and is therefore irrelevant to the comparison
-      distinctUntilChanged(
-        (prev, curr) =>
-          prev.length === curr.length &&
-          prev.every(
-            (rel, i) =>
-              rel.predicate === curr[i].predicate &&
-              rel.uris.length === curr[i].uris.length,
-          ),
-      ),
+      map(observes),
+      startWith(observes()),
+      distinctUntilChanged(compare),
     );
   }
 
@@ -215,23 +264,16 @@ export class Thing {
    * Observe changes in links from other resources to this thing
    */
   observeReverseRelations(predicate?: string): Observable<Relation[]> {
-    return merge(this.store.additions$, this.store.removals$).pipe(
-      // Note: we assume that cost of filtering by the optional predicate is not worthwhile
-      filter((quad) => quad.object.value === this.uri),
-      debounceTime(250),
-      map(() => this.reverseRelations(predicate)),
-      startWith(this.reverseRelations(predicate)),
-      // Note: label is constructed from predicate and is therefore irrelevant to the comparison
-      distinctUntilChanged(
-        (prev, curr) =>
-          prev.length === curr.length &&
-          prev.every(
-            (rel, i) =>
-              rel.predicate === curr[i].predicate &&
-              rel.uris.length === curr[i].uris.length,
-          ),
-      ),
-    );
+    return this.observeObjectChanges({
+      observes: () => this.reverseRelations(predicate),
+      compare: (prev, curr) =>
+        prev.length === curr.length &&
+        prev.every(
+          (rel, i) =>
+            rel.predicate === curr[i].predicate &&
+            rel.uris.length === curr[i].uris.length,
+        ),
+    });
   }
 
   /**

--- a/docs/elements/components/pos-switch/pos-case/readme.md
+++ b/docs/elements/components/pos-switch/pos-case/readme.md
@@ -10,13 +10,23 @@ See [storybook](https://pod-os.github.io/PodOS/storybook/?path=/story/basics--po
 
 ## Properties
 
-| Property     | Attribute     | Description                                                                   | Type      | Default     |
-| ------------ | ------------- | ----------------------------------------------------------------------------- | --------- | ----------- |
-| `else`       | `else`        | The test only evaluates to true if tests for preceding cases have failed      | `boolean` | `undefined` |
-| `ifProperty` | `if-property` | Test if the resource has the specified property (forward link)                | `string`  | `undefined` |
-| `ifRev`      | `if-rev`      | Test if the resource is the subject of the specified property (backward link) | `string`  | `undefined` |
-| `ifTypeof`   | `if-typeof`   | Test if the resource is of the specified type                                 | `string`  | `undefined` |
-| `not`        | `not`         | Negates the result of the test                                                | `boolean` | `undefined` |
+| Property        | Attribute         | Description                                                                                                                                         | Type      | Default     |
+| --------------- | ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | ----------- |
+| `else`          | `else`            | The test only evaluates to true if tests for preceding cases have failed                                                                            | `boolean` | `undefined` |
+| `everyValueEq`  | `every-value-eq`  | Test if every value linked by if-property or if-rev is equal to the attribute                                                                       | `string`  | `undefined` |
+| `everyValueGt`  | `every-value-gt`  | Test if every value linked by if-property or if-rev is strictly greater than the attribute. First a number comparison is attempted, then string.    | `string`  | `undefined` |
+| `everyValueGte` | `every-value-gte` | Test if every value linked by if-property or if-rev is greater than or equal to the attribute. First a number comparison is attempted, then string. | `string`  | `undefined` |
+| `everyValueLt`  | `every-value-lt`  | Test if every value linked by if-property or if-rev is strictly less than the attribute. First a number comparison is attempted, then string.       | `string`  | `undefined` |
+| `everyValueLte` | `every-value-lte` | Test if every value linked by if-property or if-rev is less than or equal to the attribute. First a number comparison is attempted, then string.    | `string`  | `undefined` |
+| `ifProperty`    | `if-property`     | Test if the resource has the specified property (forward link)                                                                                      | `string`  | `undefined` |
+| `ifRev`         | `if-rev`          | Test if the resource is the subject of the specified property (backward link)                                                                       | `string`  | `undefined` |
+| `ifTypeof`      | `if-typeof`       | Test if the resource is of the specified type                                                                                                       | `string`  | `undefined` |
+| `not`           | `not`             | Negates the result of the test                                                                                                                      | `boolean` | `undefined` |
+| `someValueEq`   | `some-value-eq`   | Test if some value linked by if-property or if-rev is equal to the attribute                                                                        | `string`  | `undefined` |
+| `someValueGt`   | `some-value-gt`   | Test if some value linked by if-property or if-rev is strictly greater than the attribute. First a number comparison is attempted, then string.     | `string`  | `undefined` |
+| `someValueGte`  | `some-value-gte`  | Test if some value linked by if-property or if-rev is greater than or equal to the attribute. First a number comparison is attempted, then string.  | `string`  | `undefined` |
+| `someValueLt`   | `some-value-lt`   | Test if some value linked by if-property or if-rev is strictly less than the attribute. First a number comparison is attempted, then string.        | `string`  | `undefined` |
+| `someValueLte`  | `some-value-lte`  | Test if some value linked by if-property or if-rev is less than or equal to the attribute. First a number comparison is attempted, then string.     | `string`  | `undefined` |
 
 
 ----------------------------------------------

--- a/elements/CHANGELOG.md
+++ b/elements/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.43.0
+
+### Changed
+
+- [pos-switch](https://pod-os.org/reference/elements/components/pos-switch/) and [pos-case](https://pod-os.org/reference/elements/components/pos-case/): Added attributes `(some|every)-value-(eq|gt|gte|lt|lte)` to test if some/every value linked by `if-property` or `if-rev` is equal to/greater than/less than the attribute.
+
 ## 0.42.0
 
 ### Changed

--- a/elements/src/components.d.ts
+++ b/elements/src/components.d.ts
@@ -73,6 +73,26 @@ export namespace Components {
          */
         "else"?: boolean;
         /**
+          * Test if every value linked by if-property or if-rev is equal to the attribute
+         */
+        "everyValueEq"?: string;
+        /**
+          * Test if every value linked by if-property or if-rev is strictly greater than the attribute. First a number comparison is attempted, then string.
+         */
+        "everyValueGt"?: string;
+        /**
+          * Test if every value linked by if-property or if-rev is greater than or equal to the attribute. First a number comparison is attempted, then string.
+         */
+        "everyValueGte"?: string;
+        /**
+          * Test if every value linked by if-property or if-rev is strictly less than the attribute. First a number comparison is attempted, then string.
+         */
+        "everyValueLt"?: string;
+        /**
+          * Test if every value linked by if-property or if-rev is less than or equal to the attribute. First a number comparison is attempted, then string.
+         */
+        "everyValueLte"?: string;
+        /**
           * Test if the resource has the specified property (forward link)
          */
         "ifProperty"?: string;
@@ -88,6 +108,26 @@ export namespace Components {
           * Negates the result of the test
          */
         "not"?: boolean;
+        /**
+          * Test if some value linked by if-property or if-rev is equal to the attribute
+         */
+        "someValueEq"?: string;
+        /**
+          * Test if some value linked by if-property or if-rev is strictly greater than the attribute. First a number comparison is attempted, then string.
+         */
+        "someValueGt"?: string;
+        /**
+          * Test if some value linked by if-property or if-rev is greater than or equal to the attribute. First a number comparison is attempted, then string.
+         */
+        "someValueGte"?: string;
+        /**
+          * Test if some value linked by if-property or if-rev is strictly less than the attribute. First a number comparison is attempted, then string.
+         */
+        "someValueLt"?: string;
+        /**
+          * Test if some value linked by if-property or if-rev is less than or equal to the attribute. First a number comparison is attempted, then string.
+         */
+        "someValueLte"?: string;
     }
     interface PosContainerContents {
     }
@@ -1517,6 +1557,26 @@ declare namespace LocalJSX {
          */
         "else"?: boolean;
         /**
+          * Test if every value linked by if-property or if-rev is equal to the attribute
+         */
+        "everyValueEq"?: string;
+        /**
+          * Test if every value linked by if-property or if-rev is strictly greater than the attribute. First a number comparison is attempted, then string.
+         */
+        "everyValueGt"?: string;
+        /**
+          * Test if every value linked by if-property or if-rev is greater than or equal to the attribute. First a number comparison is attempted, then string.
+         */
+        "everyValueGte"?: string;
+        /**
+          * Test if every value linked by if-property or if-rev is strictly less than the attribute. First a number comparison is attempted, then string.
+         */
+        "everyValueLt"?: string;
+        /**
+          * Test if every value linked by if-property or if-rev is less than or equal to the attribute. First a number comparison is attempted, then string.
+         */
+        "everyValueLte"?: string;
+        /**
           * Test if the resource has the specified property (forward link)
          */
         "ifProperty"?: string;
@@ -1532,6 +1592,26 @@ declare namespace LocalJSX {
           * Negates the result of the test
          */
         "not"?: boolean;
+        /**
+          * Test if some value linked by if-property or if-rev is equal to the attribute
+         */
+        "someValueEq"?: string;
+        /**
+          * Test if some value linked by if-property or if-rev is strictly greater than the attribute. First a number comparison is attempted, then string.
+         */
+        "someValueGt"?: string;
+        /**
+          * Test if some value linked by if-property or if-rev is greater than or equal to the attribute. First a number comparison is attempted, then string.
+         */
+        "someValueGte"?: string;
+        /**
+          * Test if some value linked by if-property or if-rev is strictly less than the attribute. First a number comparison is attempted, then string.
+         */
+        "someValueLt"?: string;
+        /**
+          * Test if some value linked by if-property or if-rev is less than or equal to the attribute. First a number comparison is attempted, then string.
+         */
+        "someValueLte"?: string;
     }
     interface PosContainerContents {
         "onPod-os:resource"?: (event: PosContainerContentsCustomEvent<any>) => void;
@@ -1897,6 +1977,16 @@ declare namespace LocalJSX {
         "ifRev": string;
         "not": boolean;
         "else": boolean;
+        "someValueEq": string;
+        "everyValueEq": string;
+        "someValueGt": string;
+        "everyValueGt": string;
+        "someValueGte": string;
+        "everyValueGte": string;
+        "someValueLt": string;
+        "everyValueLt": string;
+        "someValueLte": string;
+        "everyValueLte": string;
     }
     interface PosCreateNewContainerItemAttributes {
         "type": 'file' | 'folder';

--- a/elements/src/components/pos-switch/logic.ts
+++ b/elements/src/components/pos-switch/logic.ts
@@ -1,0 +1,46 @@
+export const operators = ['eq', 'gt', 'gte', 'lt', 'lte'] as const;
+export type Operator = (typeof operators)[number];
+
+export const semantics = ['some', 'every'] as const;
+export type Semantic = (typeof semantics)[number];
+
+export const operatorSemanticCombinations = semantics.flatMap(semantic =>
+  operators.map(operator => ({ semantic, operator })),
+);
+
+export function testIfValuesMatchTarget(
+  values: string[],
+  semantics: Semantic,
+  operator: Operator,
+  target: string,
+): boolean {
+  const matches = values.map(val => {
+    let cmp;
+    const numVal = Number(val);
+    const numTarget = Number(target);
+    if (!Number.isNaN(numVal) && !Number.isNaN(numTarget)) {
+      cmp = numVal - numTarget;
+    } else {
+      cmp = String(val).localeCompare(String(target));
+    }
+    switch (operator) {
+      case 'eq':
+        return cmp === 0;
+      case 'gt':
+        return cmp > 0;
+      case 'gte':
+        return cmp >= 0;
+      case 'lt':
+        return cmp < 0;
+      case 'lte':
+        return cmp <= 0;
+    }
+  });
+  if (semantics == 'some') {
+    return matches.some(Boolean);
+  } else if (semantics == 'every') {
+    return matches.every(Boolean);
+  } else {
+    throw new Error(`Unknown semantic: ${semantics}`);
+  }
+}

--- a/elements/src/components/pos-switch/pos-case/pos-case.tsx
+++ b/elements/src/components/pos-switch/pos-case/pos-case.tsx
@@ -32,6 +32,46 @@ export class PosCase {
    * The test only evaluates to true if tests for preceding cases have failed
    */
   @Prop() else?: boolean;
+  /**
+   * Test if some value linked by if-property or if-rev is equal to the attribute
+   */
+  @Prop() someValueEq?: string;
+  /**
+   * Test if every value linked by if-property or if-rev is equal to the attribute
+   */
+  @Prop() everyValueEq?: string;
+  /**
+   * Test if some value linked by if-property or if-rev is strictly greater than the attribute. First a number comparison is attempted, then string.
+   */
+  @Prop() someValueGt?: string;
+  /**
+   * Test if every value linked by if-property or if-rev is strictly greater than the attribute. First a number comparison is attempted, then string.
+   */
+  @Prop() everyValueGt?: string;
+  /**
+   * Test if some value linked by if-property or if-rev is greater than or equal to the attribute. First a number comparison is attempted, then string.
+   */
+  @Prop() someValueGte?: string;
+  /**
+   * Test if every value linked by if-property or if-rev is greater than or equal to the attribute. First a number comparison is attempted, then string.
+   */
+  @Prop() everyValueGte?: string;
+  /**
+   * Test if some value linked by if-property or if-rev is strictly less than the attribute. First a number comparison is attempted, then string.
+   */
+  @Prop() someValueLt?: string;
+  /**
+   * Test if every value linked by if-property or if-rev is strictly less than the attribute. First a number comparison is attempted, then string.
+   */
+  @Prop() everyValueLt?: string;
+  /**
+   * Test if some value linked by if-property or if-rev is less than or equal to the attribute. First a number comparison is attempted, then string.
+   */
+  @Prop() someValueLte?: string;
+  /**
+   * Test if every value linked by if-property or if-rev is less than or equal to the attribute. First a number comparison is attempted, then string.
+   */
+  @Prop() everyValueLte?: string;
 
   componentWillLoad() {
     const templateElement = this.host.querySelector('template');

--- a/elements/src/components/pos-switch/pos-switch.integration.spec.tsx
+++ b/elements/src/components/pos-switch/pos-switch.integration.spec.tsx
@@ -61,6 +61,9 @@ describe('pos-switch', () => {
             <pos-case if-typeof="http://schema.org/Thing">
               <template><div>Also a Thing</div></template>
             </pos-case>
+            <pos-case if-property="http://schema.org/name" some-value-eq="Recipe 1">
+              <template><div>This is Recipe 1</div></template>
+            </pos-case>
             <pos-case else>
               <template>Will not render as previous conditions are satisfied</template>
             </pos-case>
@@ -126,6 +129,27 @@ describe('pos-switch', () => {
         <pos-image src="https://resource.test/recipe-photo.jpg" alt="Recipe 1"></pos-image>
       </pos-picture>
       <div>Also a Thing</div>
+      `);
+    observedLiterals$.next([
+      {
+        predicate: 'http://schema.org/name',
+        label: 'name',
+        values: ['Recipe 1', 'Another recipe name'],
+      },
+    ]);
+    await page.waitForChanges();
+    expect(switchElement?.innerHTML).toEqualHtml(`
+      <div>Part of list</div>
+      <pos-label>
+        <!---->
+        Recipe 1
+      </pos-label>
+      <pos-picture>
+        <!---->
+        <pos-image src="https://resource.test/recipe-photo.jpg" alt="Recipe 1"></pos-image>
+      </pos-picture>
+      <div>Also a Thing</div>
+      <div>This is Recipe 1</div>
       `);
   });
 });

--- a/elements/src/components/pos-switch/pos-switch.integration.spec.tsx
+++ b/elements/src/components/pos-switch/pos-switch.integration.spec.tsx
@@ -7,12 +7,13 @@ import { PosPicture } from '../pos-picture/pos-picture';
 import { PosSwitch } from './pos-switch';
 import { PosResource } from '../pos-resource/pos-resource';
 import { when } from 'jest-when';
-import { RdfType, Relation, Thing } from '@pod-os/core';
+import { Literal, RdfType, Relation, Thing } from '@pod-os/core';
 import { ReplaySubject, Subject } from 'rxjs';
 
 describe('pos-switch', () => {
   it('renders template based on properties of resource, reactively', async () => {
     const os = mockPodOS();
+    const observedLiterals$ = new Subject<Literal[]>();
     const observedLabel$ = new ReplaySubject<string>();
     observedLabel$.next('Recipe 1');
     const observedTypes$ = new Subject<RdfType[]>();
@@ -25,6 +26,7 @@ describe('pos-switch', () => {
         // Label is used by pos-picture, and observeLabel by pos-label
         label: () => 'Recipe 1',
         observeLabel: () => observedLabel$,
+        observeLiterals: () => observedLiterals$,
         observeTypes: () => observedTypes$,
         observeRelations: () => observedRelations$,
         observeReverseRelations: () => observedReverseRelations$,
@@ -68,6 +70,7 @@ describe('pos-switch', () => {
     });
     expect((os.fetch as jest.Mock).mock.calls).toHaveLength(0);
     expect(page.root?.innerText).toEqualText('');
+    observedLiterals$.next([]);
     observedTypes$.next([
       {
         label: 'Recipe',

--- a/elements/src/components/pos-switch/pos-switch.spec.tsx
+++ b/elements/src/components/pos-switch/pos-switch.spec.tsx
@@ -337,6 +337,38 @@ describe('pos-switch', () => {
         `);
   });
 
+  it('renders templates if backward link value condition is met', async () => {
+    const page = await newSpecPage({
+      components: [PosSwitch],
+      html: `
+      <pos-switch>
+        <pos-case if-rev="https://schema.org/video" some-value-eq="https://video.test/video-1">
+          <template>
+            <div>Resource is video</div>
+          </template>
+        </pos-case>
+        <pos-case if-rev="https://schema.org/video" some-value-eq="https://video.test/video-missing">
+          <template>
+            <div>Should not render as condition is not met</div>
+          </template>
+        </pos-case>
+      </pos-switch>`,
+    });
+    const observedReverseRelations$ = new Subject<Relation[]>();
+    const thing = {
+      uri: 'https://pod.example/resource',
+      observeReverseRelations: () => observedReverseRelations$,
+    };
+    page.rootInstance.receiveResource(thing);
+    observedReverseRelations$.next([
+      { predicate: 'https://schema.org/video', label: 'video', uris: ['https://video.test/video-1'] },
+    ]);
+    await page.waitForChanges();
+    expect(page.root?.innerHTML).toEqualHtml(`
+        <div>Resource is video</div>
+        `);
+  });
+
   it('resets and updates when resource is changed', async () => {
     const page = await newSpecPage({
       components: [PosSwitch],

--- a/elements/src/components/pos-switch/pos-switch.spec.tsx
+++ b/elements/src/components/pos-switch/pos-switch.spec.tsx
@@ -809,16 +809,15 @@ describe('pos-switch', () => {
       observedReverseRelations: [],
       expectedResult: 'not matched',
     },
-    // TODO fails, but should match: there is some value that is not "different-name"
-    // {
-    //   conditions: 'not if-property="https://schema.org/name" some-value-eq="different-name"',
-    //   observedLiterals: [
-    //     { predicate: 'https://schema.org/name', label: 'video', values: ['the-name', 'another-name'] },
-    //   ],
-    //   observedRelations: [],
-    //   observedReverseRelations: [],
-    //   expectedResult: 'matched',
-    // },
+    {
+      conditions: 'not if-property="https://schema.org/name" some-value-eq="different-name"',
+      observedLiterals: [
+        { predicate: 'https://schema.org/name', label: 'video', values: ['the-name', 'another-name'] },
+      ],
+      observedRelations: [],
+      observedReverseRelations: [],
+      expectedResult: 'matched',
+    },
     // literal + every-value-eq
     {
       conditions: 'if-property="https://schema.org/name" every-value-eq="the-name"',

--- a/elements/src/components/pos-switch/pos-switch.spec.tsx
+++ b/elements/src/components/pos-switch/pos-switch.spec.tsx
@@ -1,6 +1,6 @@
 import { newSpecPage } from '@stencil/core/testing';
 import { PosSwitch } from './pos-switch';
-import { RdfType, Relation, Thing } from '@pod-os/core';
+import { Literal, RdfType, Relation, Thing } from '@pod-os/core';
 import { Subject } from 'rxjs';
 
 describe('pos-switch', () => {
@@ -185,7 +185,7 @@ describe('pos-switch', () => {
         `);
   });
 
-  it('renders templates if a forward link is present', async () => {
+  it('renders templates if a forward link is present (relation)', async () => {
     const page = await newSpecPage({
       components: [PosSwitch],
       html: `
@@ -203,17 +203,49 @@ describe('pos-switch', () => {
       </pos-switch>`,
     });
     const observedRelations$ = new Subject<Relation[]>();
+    const observedLiterals$ = new Subject<Literal[]>();
+
     const thing = {
       uri: 'https://pod.example/resource',
       observeRelations: () => observedRelations$,
+      observeLiterals: () => observedLiterals$,
     };
     page.rootInstance.receiveResource(thing);
+    observedLiterals$.next([]);
     observedRelations$.next([
       { predicate: 'https://schema.org/video', label: 'video', uris: ['https://video.test/video-1'] },
     ]);
     await page.waitForChanges();
     expect(page.root?.innerHTML).toEqualHtml(`
         <div>Resource has video</div>
+        `);
+  });
+
+  it('renders templates if a forward link is present (literal)', async () => {
+    const page = await newSpecPage({
+      components: [PosSwitch],
+      html: `
+      <pos-switch>
+        <pos-case if-property="https://schema.org/name">
+          <template>
+            <div>Resource has a name</div>
+          </template>
+        </pos-case>
+      </pos-switch>`,
+    });
+    const observedRelations$ = new Subject<Relation[]>();
+    const observedLiterals$ = new Subject<Literal[]>();
+    const thing = {
+      uri: 'https://pod.example/resource',
+      observeRelations: () => observedRelations$,
+      observeLiterals: () => observedLiterals$,
+    };
+    page.rootInstance.receiveResource(thing);
+    observedRelations$.next([]);
+    observedLiterals$.next([{ predicate: 'https://schema.org/name', label: 'name', values: ['name'] }]);
+    await page.waitForChanges();
+    expect(page.root?.innerHTML).toEqualHtml(`
+        <div>Resource has a name</div>
         `);
   });
 
@@ -274,13 +306,16 @@ describe('pos-switch', () => {
     const observedTypes$ = new Subject<RdfType[]>();
     const observedRelations$ = new Subject<Relation[]>();
     const observedReverseRelations$ = new Subject<Relation[]>();
+    const observedLiterals$ = new Subject<Literal[]>();
     const thing = {
       uri: 'https://pod.example/recipe1',
+      observeLiterals: () => observedLiterals$,
       observeTypes: () => observedTypes$,
       observeRelations: () => observedRelations$,
       observeReverseRelations: () => observedReverseRelations$,
     };
     page.rootInstance.receiveResource(thing);
+    observedLiterals$.next([]);
     observedTypes$.next([
       {
         label: 'Recipe',
@@ -305,7 +340,7 @@ describe('pos-switch', () => {
         `);
   });
 
-  it('renders templates if forward link value condition is met', async () => {
+  it('renders templates if forward link value condition is met (relation)', async () => {
     const page = await newSpecPage({
       components: [PosSwitch],
       html: `
@@ -323,17 +358,50 @@ describe('pos-switch', () => {
       </pos-switch>`,
     });
     const observedRelations$ = new Subject<Relation[]>();
+    const observedLiterals$ = new Subject<Literal[]>();
     const thing = {
       uri: 'https://pod.example/resource',
       observeRelations: () => observedRelations$,
+      observeLiterals: () => observedLiterals$,
     };
     page.rootInstance.receiveResource(thing);
+    observedLiterals$.next([]);
     observedRelations$.next([
       { predicate: 'https://schema.org/video', label: 'video', uris: ['https://video.test/video-1'] },
     ]);
     await page.waitForChanges();
     expect(page.root?.innerHTML).toEqualHtml(`
         <div>Resource has video</div>
+        `);
+  });
+
+  it('renders templates if forward link value condition is met (literal)', async () => {
+    const page = await newSpecPage({
+      components: [PosSwitch],
+      html: `
+      <pos-switch>
+        <pos-case if-property="https://schema.org/name" some-value-eq="Video 1">
+          <template>
+            <div>Resource has name</div>
+          </template>
+        </pos-case>
+      </pos-switch>`,
+    });
+    const observedRelations$ = new Subject<Relation[]>();
+    const observedLiterals$ = new Subject<Literal[]>();
+    const thing = {
+      uri: 'https://pod.example/resource',
+      observeRelations: () => observedRelations$,
+      observeLiterals: () => observedLiterals$,
+    };
+    page.rootInstance.receiveResource(thing);
+    observedRelations$.next([
+      { predicate: 'https://schema.org/video', label: 'video', uris: ['https://video.test/video-1'] },
+    ]);
+    observedLiterals$.next([{ predicate: 'https://schema.org/name', label: 'name', values: ['Video 1'] }]);
+    await page.waitForChanges();
+    expect(page.root?.innerHTML).toEqualHtml(`
+        <div>Resource has name</div>
         `);
   });
 
@@ -392,11 +460,14 @@ describe('pos-switch', () => {
       </pos-switch>`,
     });
     const observedRelations$ = new Subject<Relation[]>();
+    const observedLiterals$ = new Subject<Literal[]>();
     const thing = {
       uri: 'https://pod.example/resource',
+      observeLiterals: () => observedLiterals$,
       observeRelations: () => observedRelations$,
     };
     page.rootInstance.receiveResource(thing);
+    observedLiterals$.next([]);
     observedRelations$.next([
       {
         predicate: 'https://schema.org/video',

--- a/elements/src/components/pos-switch/pos-switch.spec.tsx
+++ b/elements/src/components/pos-switch/pos-switch.spec.tsx
@@ -551,7 +551,7 @@ describe('pos-switch', () => {
         </pos-case>
         <pos-case if-property="https://schema.org/name" every-value-gt="charlie">
           <template>
-            <div>Not shown: ! bravo and charlie >  charlie</div>
+            <div>Not shown: ! bravo and charlie > charlie</div>
           </template>
         </pos-case>
         <pos-case else>
@@ -570,6 +570,102 @@ describe('pos-switch', () => {
     };
     page.rootInstance.receiveResource(thing);
     observedLiterals$.next([{ predicate: 'https://schema.org/name', label: 'name', values: ['bravo', 'charlie'] }]);
+    observedRelations$.next([]);
+    await page.waitForChanges();
+    expect(page.root?.innerHTML).toEqualHtml(`
+        <div>No conditions match</div>
+        `);
+  });
+
+  it('does not render templates when compareValue indicates that some-value-(lt|lte|gt|gte) is not met (numeric)', async () => {
+    const page = await newSpecPage({
+      components: [PosSwitch],
+      html: `
+      <pos-switch>
+        <pos-case if-property="https://schema.org/name" some-value-lt="3">
+          <template>
+            <div>Not shown: ! 20 < 3</div>
+          </template>
+        </pos-case>
+        <pos-case if-property="https://schema.org/name" some-value-lte="3">
+          <template>
+            <div>Not shown: ! 20 <= 3</div>
+          </template>
+        </pos-case>
+        <pos-case if-property="https://schema.org/name" some-value-gte="100">
+          <template>
+            <div>Not shown: ! 20 >= 100</div>
+          </template>
+        </pos-case>
+        <pos-case if-property="https://schema.org/name" some-value-gt="100">
+          <template>
+            <div>Not shown: ! 20 > 100</div>
+          </template>
+        </pos-case>
+        <pos-case else>
+          <template>
+            <div>No conditions match</div>
+          </template>
+        </pos-case>
+      </pos-switch>`,
+    });
+    const observedRelations$ = new Subject<Relation[]>();
+    const observedLiterals$ = new Subject<Literal[]>();
+    const thing = {
+      uri: 'https://pod.example/resource',
+      observeLiterals: () => observedLiterals$,
+      observeRelations: () => observedRelations$,
+    };
+    page.rootInstance.receiveResource(thing);
+    observedLiterals$.next([{ predicate: 'https://schema.org/name', label: 'name', values: ['20'] }]);
+    observedRelations$.next([]);
+    await page.waitForChanges();
+    expect(page.root?.innerHTML).toEqualHtml(`
+        <div>No conditions match</div>
+        `);
+  });
+
+  it('does not render templates when compareValue indicates that every-value-(lt|lte|gt|gte) is not met (numeric)', async () => {
+    const page = await newSpecPage({
+      components: [PosSwitch],
+      html: `
+      <pos-switch>
+        <pos-case if-property="https://schema.org/name" every-value-lt="4">
+          <template>
+            <div>Not shown: ! 20 and 30 < 4</div>
+          </template>
+        </pos-case>
+        <pos-case if-property="https://schema.org/name" every-value-lte="4">
+          <template>
+            <div>Not shown: ! 20 and 30 <= 4</div>
+          </template>
+        </pos-case>
+        <pos-case if-property="https://schema.org/name" every-value-gte="100">
+          <template>
+            <div>Not shown: ! 20 and 30 >= 100</div>
+          </template>
+        </pos-case>
+        <pos-case if-property="https://schema.org/name" every-value-gt="100">
+          <template>
+            <div>Not shown: ! 20 and 30 > 100</div>
+          </template>
+        </pos-case>
+        <pos-case else>
+          <template>
+            <div>No conditions match</div>
+          </template>
+        </pos-case>
+      </pos-switch>`,
+    });
+    const observedRelations$ = new Subject<Relation[]>();
+    const observedLiterals$ = new Subject<Literal[]>();
+    const thing = {
+      uri: 'https://pod.example/resource',
+      observeLiterals: () => observedLiterals$,
+      observeRelations: () => observedRelations$,
+    };
+    page.rootInstance.receiveResource(thing);
+    observedLiterals$.next([{ predicate: 'https://schema.org/name', label: 'name', values: ['20', '30'] }]);
     observedRelations$.next([]);
     await page.waitForChanges();
     expect(page.root?.innerHTML).toEqualHtml(`

--- a/elements/src/components/pos-switch/pos-switch.spec.tsx
+++ b/elements/src/components/pos-switch/pos-switch.spec.tsx
@@ -781,4 +781,90 @@ describe('pos-switch', () => {
     await page.waitForChanges();
     expect(page.root?.innerText).toEqualText('Video.');
   });
+
+  it.each([
+    // relation + some-value-eq
+    {
+      conditions: 'if-property="https://schema.org/video" some-value-eq="https://video.test/video-1"',
+      observedLiterals: [],
+      observedRelations: [
+        {
+          predicate: 'https://schema.org/video',
+          label: 'video',
+          uris: ['https://video.test/video-1', 'https://video.test/video-2'],
+        },
+      ],
+      observedReverseRelations: [],
+      expectedResult: 'matched',
+    },
+    {
+      conditions: 'not if-property="https://schema.org/video" some-value-eq="https://video.test/video-1"',
+      observedLiterals: [],
+      observedRelations: [
+        {
+          predicate: 'https://schema.org/video',
+          label: 'video',
+          uris: ['https://video.test/video-1', 'https://video.test/video-2'],
+        },
+      ],
+      observedReverseRelations: [],
+      expectedResult: 'not matched',
+    },
+    // literal + some-value-eq
+    {
+      conditions: 'if-property="https://schema.org/name" some-value-eq="the-name"',
+      observedLiterals: [
+        { predicate: 'https://schema.org/name', label: 'video', values: ['the-name', 'another-name'] },
+      ],
+      observedRelations: [],
+      observedReverseRelations: [],
+      expectedResult: 'matched',
+    },
+    {
+      conditions: 'not if-property="https://schema.org/name" some-value-eq="the-name"',
+      observedLiterals: [
+        { predicate: 'https://schema.org/name', label: 'video', values: ['the-name', 'another-name'] },
+      ],
+      observedRelations: [],
+      observedReverseRelations: [],
+      expectedResult: 'not matched',
+    },
+  ])(
+    `renders templates if condition is met: $conditions `,
+    async ({ conditions, observedLiterals, observedRelations, observedReverseRelations, expectedResult }) => {
+      const page = await newSpecPage({
+        components: [PosSwitch],
+        html: `
+      <pos-switch>
+        <pos-case ${conditions}>
+          <template>
+            <div>Condition is matched</div>
+          </template>
+        </pos-case>
+        <pos-case else>
+          <template>
+            <div>Condition is not matched</div>
+          </template>
+        </pos-case>
+      </pos-switch>`,
+      });
+      const observedRelations$ = new Subject<Relation[]>();
+      const observedLiterals$ = new Subject<Literal[]>();
+      const observedReverseRelations$ = new Subject<Relation[]>();
+      const thing = {
+        uri: 'https://pod.example/resource',
+        observeRelations: () => observedRelations$,
+        observeLiterals: () => observedLiterals$,
+        observedReverseRelations: () => observedLiterals$,
+      };
+      page.rootInstance.receiveResource(thing);
+      observedLiterals$.next(observedLiterals);
+      observedRelations$.next(observedRelations);
+      observedReverseRelations$.next(observedReverseRelations);
+      await page.waitForChanges();
+      expect(page.root?.innerHTML).toEqualHtml(`
+        <div>Condition is ${expectedResult}</div>
+        `);
+    },
+  );
 });

--- a/elements/src/components/pos-switch/pos-switch.spec.tsx
+++ b/elements/src/components/pos-switch/pos-switch.spec.tsx
@@ -673,6 +673,69 @@ describe('pos-switch', () => {
         `);
   });
 
+  it('renders templates when property is absent (not if-property)', async () => {
+    const page = await newSpecPage({
+      components: [PosSwitch],
+      html: `
+      <pos-switch>
+        <pos-case not if-property="https://schema.org/description">
+          <template>
+            <div>Resource has no description</div>
+          </template>
+        </pos-case>
+        <pos-case if-property="https://schema.org/description">
+          <template>
+            <div>Should not render as description is not present</div>
+          </template>
+        </pos-case>
+      </pos-switch>`,
+    });
+    const observedRelations$ = new Subject<Relation[]>();
+    const observedLiterals$ = new Subject<Literal[]>();
+    const thing = {
+      uri: 'https://pod.example/resource',
+      observeRelations: () => observedRelations$,
+      observeLiterals: () => observedLiterals$,
+    };
+    page.rootInstance.receiveResource(thing);
+    observedLiterals$.next([]);
+    observedRelations$.next([]);
+    await page.waitForChanges();
+    expect(page.root?.innerHTML).toEqualHtml(`
+        <div>Resource has no description</div>
+        `);
+  });
+
+  it('renders templates when backward link is absent (not if-rev)', async () => {
+    const page = await newSpecPage({
+      components: [PosSwitch],
+      html: `
+      <pos-switch>
+        <pos-case not if-rev="https://schema.org/video">
+          <template>
+            <div>Resource is not a video object</div>
+          </template>
+        </pos-case>
+        <pos-case if-rev="https://schema.org/video">
+          <template>
+            <div>Should not render as video reverse relation is not present</div>
+          </template>
+        </pos-case>
+      </pos-switch>`,
+    });
+    const observedReverseRelations$ = new Subject<Relation[]>();
+    const thing = {
+      uri: 'https://pod.example/resource',
+      observeReverseRelations: () => observedReverseRelations$,
+    };
+    page.rootInstance.receiveResource(thing);
+    observedReverseRelations$.next([]);
+    await page.waitForChanges();
+    expect(page.root?.innerHTML).toEqualHtml(`
+        <div>Resource is not a video object</div>
+        `);
+  });
+
   it('resets and updates when resource is changed', async () => {
     const page = await newSpecPage({
       components: [PosSwitch],

--- a/elements/src/components/pos-switch/pos-switch.spec.tsx
+++ b/elements/src/components/pos-switch/pos-switch.spec.tsx
@@ -369,6 +369,47 @@ describe('pos-switch', () => {
         `);
   });
 
+  it('does not render templates when compareValue indicates that (some|every)-value-eq is not met', async () => {
+    const page = await newSpecPage({
+      components: [PosSwitch],
+      html: `
+      <pos-switch>
+        <pos-case if-property="https://schema.org/video" some-value-eq="https://video.test/video-missing">
+          <template>
+            <div>some-value-eq not https://video.test/video-missing</div>
+          </template>
+        </pos-case>
+        <pos-case if-property="https://schema.org/video" every-value-eq="https://video.test/video-1">
+          <template>
+            <div>every-value-eq not https://video.test/video-1</div>
+          </template>
+        </pos-case>
+        <pos-case else>
+          <template>
+            <div>No conditions match</div>
+          </template>
+        </pos-case>
+      </pos-switch>`,
+    });
+    const observedRelations$ = new Subject<Relation[]>();
+    const thing = {
+      uri: 'https://pod.example/resource',
+      observeRelations: () => observedRelations$,
+    };
+    page.rootInstance.receiveResource(thing);
+    observedRelations$.next([
+      {
+        predicate: 'https://schema.org/video',
+        label: 'video',
+        uris: ['https://video.test/video-1', 'https://video.test/video-2'],
+      },
+    ]);
+    await page.waitForChanges();
+    expect(page.root?.innerHTML).toEqualHtml(`
+        <div>No conditions match</div>
+        `);
+  });
+
   it('resets and updates when resource is changed', async () => {
     const page = await newSpecPage({
       components: [PosSwitch],

--- a/elements/src/components/pos-switch/pos-switch.spec.tsx
+++ b/elements/src/components/pos-switch/pos-switch.spec.tsx
@@ -836,16 +836,15 @@ describe('pos-switch', () => {
       observedReverseRelations: [],
       expectedResult: 'matched',
     },
-    // TODO fails, but should match: not every value is "the-name"
-    // {
-    //   conditions: 'not if-property="https://schema.org/name" every-value-eq="the-name"',
-    //   observedLiterals: [
-    //     { predicate: 'https://schema.org/name', label: 'video', values: ['the-name', 'another-name'] },
-    //   ],
-    //   observedRelations: [],
-    //   observedReverseRelations: [],
-    //   expectedResult: 'matched',
-    // },
+    {
+      conditions: 'not if-property="https://schema.org/name" every-value-eq="the-name"',
+      observedLiterals: [
+        { predicate: 'https://schema.org/name', label: 'video', values: ['the-name', 'another-name'] },
+      ],
+      observedRelations: [],
+      observedReverseRelations: [],
+      expectedResult: 'matched',
+    },
     // relation + some-value-eq
     {
       conditions: 'if-property="https://schema.org/video" some-value-eq="https://video.test/video-1"',

--- a/elements/src/components/pos-switch/pos-switch.spec.tsx
+++ b/elements/src/components/pos-switch/pos-switch.spec.tsx
@@ -1,6 +1,5 @@
 import { newSpecPage } from '@stencil/core/testing';
 import { PosSwitch } from './pos-switch';
-import { when } from 'jest-when';
 import { RdfType, Relation, Thing } from '@pod-os/core';
 import { Subject } from 'rxjs';
 
@@ -303,6 +302,38 @@ describe('pos-switch', () => {
         <div>Recipe.</div>
         <div>Image.</div>
         <div>Recipe list.</div>
+        `);
+  });
+
+  it('renders templates if forward link value condition is met', async () => {
+    const page = await newSpecPage({
+      components: [PosSwitch],
+      html: `
+      <pos-switch>
+        <pos-case if-property="https://schema.org/video" some-value-eq="https://video.test/video-1">
+          <template>
+            <div>Resource has video</div>
+          </template>
+        </pos-case>
+        <pos-case if-property="https://schema.org/video" some-value-eq="https://video.test/video-missing">
+          <template>
+            <div>Should not render as value condition is not met</div>
+          </template>
+        </pos-case>
+      </pos-switch>`,
+    });
+    const observedRelations$ = new Subject<Relation[]>();
+    const thing = {
+      uri: 'https://pod.example/resource',
+      observeRelations: () => observedRelations$,
+    };
+    page.rootInstance.receiveResource(thing);
+    observedRelations$.next([
+      { predicate: 'https://schema.org/video', label: 'video', uris: ['https://video.test/video-1'] },
+    ]);
+    await page.waitForChanges();
+    expect(page.root?.innerHTML).toEqualHtml(`
+        <div>Resource has video</div>
         `);
   });
 

--- a/elements/src/components/pos-switch/pos-switch.spec.tsx
+++ b/elements/src/components/pos-switch/pos-switch.spec.tsx
@@ -4,29 +4,30 @@ import { Literal, RdfType, Relation, Thing } from '@pod-os/core';
 import { Subject } from 'rxjs';
 
 describe('pos-switch', () => {
-  it('contains only templates initially', async () => {
-    const page = await newSpecPage({
-      components: [PosSwitch],
-      html: `
+  describe('template loading', () => {
+    it('contains only templates initially', async () => {
+      const page = await newSpecPage({
+        components: [PosSwitch],
+        html: `
       <pos-switch>
         <pos-case if-typeof="http://schema.org/Recipe">
           <template><div>Test</div></template>
         </pos-case>
       </pos-switch>`,
-    });
-    expect(page.root).toEqualHtml(`
+      });
+      expect(page.root).toEqualHtml(`
       <pos-switch>
         <pos-case if-typeof="http://schema.org/Recipe">
           <template><div>Test</div></template>
         </pos-case>
       </pos-switch>
         `);
-  });
+    });
 
-  it('loads condition templates', async () => {
-    const page = await newSpecPage({
-      components: [PosSwitch],
-      html: `
+    it('loads condition templates', async () => {
+      const page = await newSpecPage({
+        components: [PosSwitch],
+        html: `
       <pos-switch>
         <pos-case if-typeof="http://schema.org/Recipe">
           <template><div>Recipe</div></template>
@@ -35,16 +36,16 @@ describe('pos-switch', () => {
           <template><div>Video</div></template>
         </pos-case>
       </pos-switch>`,
+      });
+      expect(page.rootInstance.caseElements.length).toEqual(2);
+      expect(page.rootInstance.caseElements[0].getAttribute('if-typeof')).toEqual('http://schema.org/Recipe');
+      expect(page.rootInstance.caseElements[1].getAttribute('if-typeof')).toEqual('http://schema.org/Video');
     });
-    expect(page.rootInstance.caseElements.length).toEqual(2);
-    expect(page.rootInstance.caseElements[0].getAttribute('if-typeof')).toEqual('http://schema.org/Recipe');
-    expect(page.rootInstance.caseElements[1].getAttribute('if-typeof')).toEqual('http://schema.org/Video');
-  });
 
-  it('does not load nested templates', async () => {
-    const page = await newSpecPage({
-      components: [PosSwitch],
-      html: `
+    it('does not load nested templates', async () => {
+      const page = await newSpecPage({
+        components: [PosSwitch],
+        html: `
       <pos-switch>
         <pos-case if-typeof="http://schema.org/Recipe">
           <template>
@@ -52,18 +53,19 @@ describe('pos-switch', () => {
           </template>
         </pos-case>
       </pos-switch>`,
+      });
+      expect(page.rootInstance.caseElements.length).toEqual(1);
+      expect(page.rootInstance.caseElements[0].getAttribute('if-typeof')).toEqual('http://schema.org/Recipe');
     });
-    expect(page.rootInstance.caseElements.length).toEqual(1);
-    expect(page.rootInstance.caseElements[0].getAttribute('if-typeof')).toEqual('http://schema.org/Recipe');
-  });
 
-  it('displays error on missing template', async () => {
-    const page = await newSpecPage({
-      components: [PosSwitch],
-      html: `<pos-switch></pos-switch>`,
+    it('displays error on missing template', async () => {
+      const page = await newSpecPage({
+        components: [PosSwitch],
+        html: `<pos-switch></pos-switch>`,
+      });
+      const el: HTMLElement = page.root as unknown as HTMLElement;
+      expect(el.textContent).toEqual('No pos-case elements found');
     });
-    const el: HTMLElement = page.root as unknown as HTMLElement;
-    expect(el.textContent).toEqual('No pos-case elements found');
   });
 
   it('renders matching condition templates, reactively', async () => {
@@ -106,179 +108,60 @@ describe('pos-switch', () => {
         `);
   });
 
-  it('renders matching condition templates with if-else logic', async () => {
-    const page = await newSpecPage({
-      components: [PosSwitch],
-      html: `
+  describe('if-else logic', () => {
+    it('renders matching condition templates with if-else logic', async () => {
+      const page = await newSpecPage({
+        components: [PosSwitch],
+        html: `
       <pos-switch>
         <pos-case if-typeof="http://schema.org/Video"><template><div>Video 1</div></template></pos-case></pos-case>
         <pos-case else if-typeof="http://schema.org/Recipe"><template><div>Recipe 1</div></template></pos-case>
         <pos-case else if-typeof="http://schema.org/Recipe"><template><div>Recipe 2</div></template></pos-case>
         <pos-case else><template><div>No matches</div></template></pos-case>
       </pos-switch>`,
-    });
-    const observedTypes$ = new Subject<RdfType[]>();
-    const thing = {
-      observeTypes: () => observedTypes$,
-    } as unknown as Thing;
-    page.rootInstance.receiveResource(thing);
-    observedTypes$.next([
-      {
-        label: 'Recipe',
-        uri: 'http://schema.org/Recipe',
-      },
-    ]);
-    await page.waitForChanges();
-    expect(page.root?.innerHTML).toEqualHtml(`
+      });
+      const observedTypes$ = new Subject<RdfType[]>();
+      const thing = {
+        observeTypes: () => observedTypes$,
+      } as unknown as Thing;
+      page.rootInstance.receiveResource(thing);
+      observedTypes$.next([
+        {
+          label: 'Recipe',
+          uri: 'http://schema.org/Recipe',
+        },
+      ]);
+      await page.waitForChanges();
+      expect(page.root?.innerHTML).toEqualHtml(`
         <div>Recipe 1</div>
         `);
-  });
+    });
 
-  it('renders final else condition if no other templates match', async () => {
-    const page = await newSpecPage({
-      components: [PosSwitch],
-      html: `
+    it('renders final else condition if no other templates match', async () => {
+      const page = await newSpecPage({
+        components: [PosSwitch],
+        html: `
       <pos-switch>
         <pos-case if-typeof="http://schema.org/Video"><template><div>Video 1</div></template></pos-case>
         <pos-case else><template><div>No matches</div></template></pos-case>
       </pos-switch>`,
-    });
-    const observedTypes$ = new Subject<RdfType[]>();
-    const thing = {
-      observeTypes: () => observedTypes$,
-    } as unknown as Thing;
-    page.rootInstance.receiveResource(thing);
-    observedTypes$.next([
-      {
-        label: 'Recipe',
-        uri: 'http://schema.org/Recipe',
-      },
-    ]);
-    await page.waitForChanges();
-    expect(page.root?.innerHTML).toEqualHtml(`
+      });
+      const observedTypes$ = new Subject<RdfType[]>();
+      const thing = {
+        observeTypes: () => observedTypes$,
+      } as unknown as Thing;
+      page.rootInstance.receiveResource(thing);
+      observedTypes$.next([
+        {
+          label: 'Recipe',
+          uri: 'http://schema.org/Recipe',
+        },
+      ]);
+      await page.waitForChanges();
+      expect(page.root?.innerHTML).toEqualHtml(`
         <div>No matches</div>
         `);
-  });
-
-  it('renders matching condition with negation', async () => {
-    const page = await newSpecPage({
-      components: [PosSwitch],
-      html: `
-      <pos-switch>
-        <pos-case not if-typeof="http://schema.org/Video"><template><div>Not a Video</div></template></pos-case>
-      </pos-switch>`,
     });
-    const observedTypes$ = new Subject<RdfType[]>();
-    const thing = {
-      observeTypes: () => observedTypes$,
-    } as unknown as Thing;
-    page.rootInstance.receiveResource(thing);
-    observedTypes$.next([
-      {
-        label: 'Recipe',
-        uri: 'http://schema.org/Recipe',
-      },
-    ]);
-    await page.waitForChanges();
-    expect(page.root?.innerHTML).toEqualHtml(`
-        <div>Not a Video</div>
-        `);
-  });
-
-  it('renders templates if a forward link is present (relation)', async () => {
-    const page = await newSpecPage({
-      components: [PosSwitch],
-      html: `
-      <pos-switch>
-        <pos-case if-property="https://schema.org/video">
-          <template>
-            <div>Resource has video</div>
-          </template>
-        </pos-case>
-        <pos-case if-property="https://schema.org/description">
-          <template>
-            <div>Should not render as schema:description is not present</div>
-          </template>
-        </pos-case>
-      </pos-switch>`,
-    });
-    const observedRelations$ = new Subject<Relation[]>();
-    const observedLiterals$ = new Subject<Literal[]>();
-
-    const thing = {
-      uri: 'https://pod.example/resource',
-      observeRelations: () => observedRelations$,
-      observeLiterals: () => observedLiterals$,
-    };
-    page.rootInstance.receiveResource(thing);
-    observedLiterals$.next([]);
-    observedRelations$.next([
-      { predicate: 'https://schema.org/video', label: 'video', uris: ['https://video.test/video-1'] },
-    ]);
-    await page.waitForChanges();
-    expect(page.root?.innerHTML).toEqualHtml(`
-        <div>Resource has video</div>
-        `);
-  });
-
-  it('renders templates if a forward link is present (literal)', async () => {
-    const page = await newSpecPage({
-      components: [PosSwitch],
-      html: `
-      <pos-switch>
-        <pos-case if-property="https://schema.org/name">
-          <template>
-            <div>Resource has a name</div>
-          </template>
-        </pos-case>
-      </pos-switch>`,
-    });
-    const observedRelations$ = new Subject<Relation[]>();
-    const observedLiterals$ = new Subject<Literal[]>();
-    const thing = {
-      uri: 'https://pod.example/resource',
-      observeRelations: () => observedRelations$,
-      observeLiterals: () => observedLiterals$,
-    };
-    page.rootInstance.receiveResource(thing);
-    observedRelations$.next([]);
-    observedLiterals$.next([{ predicate: 'https://schema.org/name', label: 'name', values: ['name'] }]);
-    await page.waitForChanges();
-    expect(page.root?.innerHTML).toEqualHtml(`
-        <div>Resource has a name</div>
-        `);
-  });
-
-  it('renders templates if a backward link is present', async () => {
-    const page = await newSpecPage({
-      components: [PosSwitch],
-      html: `
-      <pos-switch>
-        <pos-case if-rev="https://schema.org/video">
-          <template>
-            <div>Resource is video</div>
-          </template>
-        </pos-case>
-        <pos-case if-rev="https://schema.org/subjectOf">
-          <template>
-            <div>Should not render as resource is not object of schema:subjectOf</div>
-          </template>
-        </pos-case>
-      </pos-switch>`,
-    });
-    const observedReverseRelations$ = new Subject<Relation[]>();
-    const thing = {
-      uri: 'https://pod.example/resource',
-      observeReverseRelations: () => observedReverseRelations$,
-    };
-    page.rootInstance.receiveResource(thing);
-    observedReverseRelations$.next([
-      { predicate: 'https://schema.org/video', label: 'video', uris: ['https://video.test/video-1'] },
-    ]);
-    await page.waitForChanges();
-    expect(page.root?.innerHTML).toEqualHtml(`
-        <div>Resource is video</div>
-        `);
   });
 
   it('supports mixed test conditions', async () => {
@@ -340,402 +223,6 @@ describe('pos-switch', () => {
         `);
   });
 
-  it('renders templates if forward link value condition is met (relation)', async () => {
-    const page = await newSpecPage({
-      components: [PosSwitch],
-      html: `
-      <pos-switch>
-        <pos-case if-property="https://schema.org/video" some-value-eq="https://video.test/video-1">
-          <template>
-            <div>Resource has video</div>
-          </template>
-        </pos-case>
-        <pos-case if-property="https://schema.org/video" some-value-eq="https://video.test/video-missing">
-          <template>
-            <div>Should not render as value condition is not met</div>
-          </template>
-        </pos-case>
-      </pos-switch>`,
-    });
-    const observedRelations$ = new Subject<Relation[]>();
-    const observedLiterals$ = new Subject<Literal[]>();
-    const thing = {
-      uri: 'https://pod.example/resource',
-      observeRelations: () => observedRelations$,
-      observeLiterals: () => observedLiterals$,
-    };
-    page.rootInstance.receiveResource(thing);
-    observedLiterals$.next([]);
-    observedRelations$.next([
-      { predicate: 'https://schema.org/video', label: 'video', uris: ['https://video.test/video-1'] },
-    ]);
-    await page.waitForChanges();
-    expect(page.root?.innerHTML).toEqualHtml(`
-        <div>Resource has video</div>
-        `);
-  });
-
-  it('renders templates if forward link value condition is met (literal)', async () => {
-    const page = await newSpecPage({
-      components: [PosSwitch],
-      html: `
-      <pos-switch>
-        <pos-case if-property="https://schema.org/name" some-value-eq="Video 1">
-          <template>
-            <div>Resource has name</div>
-          </template>
-        </pos-case>
-      </pos-switch>`,
-    });
-    const observedRelations$ = new Subject<Relation[]>();
-    const observedLiterals$ = new Subject<Literal[]>();
-    const thing = {
-      uri: 'https://pod.example/resource',
-      observeRelations: () => observedRelations$,
-      observeLiterals: () => observedLiterals$,
-    };
-    page.rootInstance.receiveResource(thing);
-    observedRelations$.next([
-      { predicate: 'https://schema.org/video', label: 'video', uris: ['https://video.test/video-1'] },
-    ]);
-    observedLiterals$.next([{ predicate: 'https://schema.org/name', label: 'name', values: ['Video 1'] }]);
-    await page.waitForChanges();
-    expect(page.root?.innerHTML).toEqualHtml(`
-        <div>Resource has name</div>
-        `);
-  });
-
-  it('renders templates if backward link value condition is met', async () => {
-    const page = await newSpecPage({
-      components: [PosSwitch],
-      html: `
-      <pos-switch>
-        <pos-case if-rev="https://schema.org/video" some-value-eq="https://video.test/video-1">
-          <template>
-            <div>Resource is video</div>
-          </template>
-        </pos-case>
-        <pos-case if-rev="https://schema.org/video" some-value-eq="https://video.test/video-missing">
-          <template>
-            <div>Should not render as condition is not met</div>
-          </template>
-        </pos-case>
-      </pos-switch>`,
-    });
-    const observedReverseRelations$ = new Subject<Relation[]>();
-    const thing = {
-      uri: 'https://pod.example/resource',
-      observeReverseRelations: () => observedReverseRelations$,
-    };
-    page.rootInstance.receiveResource(thing);
-    observedReverseRelations$.next([
-      { predicate: 'https://schema.org/video', label: 'video', uris: ['https://video.test/video-1'] },
-    ]);
-    await page.waitForChanges();
-    expect(page.root?.innerHTML).toEqualHtml(`
-        <div>Resource is video</div>
-        `);
-  });
-
-  it('does not render templates when compareValue indicates that (some|every)-value-eq is not met', async () => {
-    const page = await newSpecPage({
-      components: [PosSwitch],
-      html: `
-      <pos-switch>
-        <pos-case if-property="https://schema.org/video" some-value-eq="https://video.test/video-missing">
-          <template>
-            <div>some-value-eq not https://video.test/video-missing</div>
-          </template>
-        </pos-case>
-        <pos-case if-property="https://schema.org/video" every-value-eq="https://video.test/video-1">
-          <template>
-            <div>every-value-eq not https://video.test/video-1</div>
-          </template>
-        </pos-case>
-        <pos-case else>
-          <template>
-            <div>No conditions match</div>
-          </template>
-        </pos-case>
-      </pos-switch>`,
-    });
-    const observedRelations$ = new Subject<Relation[]>();
-    const observedLiterals$ = new Subject<Literal[]>();
-    const thing = {
-      uri: 'https://pod.example/resource',
-      observeLiterals: () => observedLiterals$,
-      observeRelations: () => observedRelations$,
-    };
-    page.rootInstance.receiveResource(thing);
-    observedLiterals$.next([]);
-    observedRelations$.next([
-      {
-        predicate: 'https://schema.org/video',
-        label: 'video',
-        uris: ['https://video.test/video-1', 'https://video.test/video-2'],
-      },
-    ]);
-    await page.waitForChanges();
-    expect(page.root?.innerHTML).toEqualHtml(`
-        <div>No conditions match</div>
-        `);
-  });
-
-  it('does not render templates when compareValue indicates that some-value-(lt|lte|gt|gte) is not met (string)', async () => {
-    const page = await newSpecPage({
-      components: [PosSwitch],
-      html: `
-      <pos-switch>
-        <pos-case if-property="https://schema.org/name" some-value-lt="bravo">
-          <template>
-            <div>Not shown: ! bravo < bravo </div>
-          </template>
-        </pos-case>
-        <pos-case if-property="https://schema.org/name" some-value-lte="alpha">
-          <template>
-            <div>Not shown: ! bravo <= alpha</div>
-          </template>
-        </pos-case>
-        <pos-case if-property="https://schema.org/name" some-value-gte="charlie">
-          <template>
-            <div>Not shown: ! bravo >= charlie</div>
-          </template>
-        </pos-case>
-        <pos-case if-property="https://schema.org/name" some-value-gt="bravo">
-          <template>
-            <div>Not shown: ! bravo > bravo</div>
-          </template>
-        </pos-case>
-        <pos-case else>
-          <template>
-            <div>No conditions match</div>
-          </template>
-        </pos-case>
-      </pos-switch>`,
-    });
-    const observedRelations$ = new Subject<Relation[]>();
-    const observedLiterals$ = new Subject<Literal[]>();
-    const thing = {
-      uri: 'https://pod.example/resource',
-      observeLiterals: () => observedLiterals$,
-      observeRelations: () => observedRelations$,
-    };
-    page.rootInstance.receiveResource(thing);
-    observedLiterals$.next([{ predicate: 'https://schema.org/name', label: 'name', values: ['bravo'] }]);
-    observedRelations$.next([]);
-    await page.waitForChanges();
-    expect(page.root?.innerHTML).toEqualHtml(`
-        <div>No conditions match</div>
-        `);
-  });
-
-  it('does not render templates when compareValue indicates that every-value-(lt|lte|gt|gte) is not met (string)', async () => {
-    const page = await newSpecPage({
-      components: [PosSwitch],
-      html: `
-      <pos-switch>
-        <pos-case if-property="https://schema.org/name" every-value-lt="bravo">
-          <template>
-            <div>Not shown: ! bravo and charlie < bravo </div>
-          </template>
-        </pos-case>
-        <pos-case if-property="https://schema.org/name" every-value-lte="bravo">
-          <template>
-            <div>Not shown: ! bravo and charlie <= bravo</div>
-          </template>
-        </pos-case>
-        <pos-case if-property="https://schema.org/name" every-value-gte="charlie">
-          <template>
-            <div>Not shown: ! bravo and charlie >=  charlie</div>
-          </template>
-        </pos-case>
-        <pos-case if-property="https://schema.org/name" every-value-gt="charlie">
-          <template>
-            <div>Not shown: ! bravo and charlie > charlie</div>
-          </template>
-        </pos-case>
-        <pos-case else>
-          <template>
-            <div>No conditions match</div>
-          </template>
-        </pos-case>
-      </pos-switch>`,
-    });
-    const observedRelations$ = new Subject<Relation[]>();
-    const observedLiterals$ = new Subject<Literal[]>();
-    const thing = {
-      uri: 'https://pod.example/resource',
-      observeLiterals: () => observedLiterals$,
-      observeRelations: () => observedRelations$,
-    };
-    page.rootInstance.receiveResource(thing);
-    observedLiterals$.next([{ predicate: 'https://schema.org/name', label: 'name', values: ['bravo', 'charlie'] }]);
-    observedRelations$.next([]);
-    await page.waitForChanges();
-    expect(page.root?.innerHTML).toEqualHtml(`
-        <div>No conditions match</div>
-        `);
-  });
-
-  it('does not render templates when compareValue indicates that some-value-(lt|lte|gt|gte) is not met (numeric)', async () => {
-    const page = await newSpecPage({
-      components: [PosSwitch],
-      html: `
-      <pos-switch>
-        <pos-case if-property="https://schema.org/name" some-value-lt="3">
-          <template>
-            <div>Not shown: ! 20 < 3</div>
-          </template>
-        </pos-case>
-        <pos-case if-property="https://schema.org/name" some-value-lte="3">
-          <template>
-            <div>Not shown: ! 20 <= 3</div>
-          </template>
-        </pos-case>
-        <pos-case if-property="https://schema.org/name" some-value-gte="100">
-          <template>
-            <div>Not shown: ! 20 >= 100</div>
-          </template>
-        </pos-case>
-        <pos-case if-property="https://schema.org/name" some-value-gt="100">
-          <template>
-            <div>Not shown: ! 20 > 100</div>
-          </template>
-        </pos-case>
-        <pos-case else>
-          <template>
-            <div>No conditions match</div>
-          </template>
-        </pos-case>
-      </pos-switch>`,
-    });
-    const observedRelations$ = new Subject<Relation[]>();
-    const observedLiterals$ = new Subject<Literal[]>();
-    const thing = {
-      uri: 'https://pod.example/resource',
-      observeLiterals: () => observedLiterals$,
-      observeRelations: () => observedRelations$,
-    };
-    page.rootInstance.receiveResource(thing);
-    observedLiterals$.next([{ predicate: 'https://schema.org/name', label: 'name', values: ['20'] }]);
-    observedRelations$.next([]);
-    await page.waitForChanges();
-    expect(page.root?.innerHTML).toEqualHtml(`
-        <div>No conditions match</div>
-        `);
-  });
-
-  it('does not render templates when compareValue indicates that every-value-(lt|lte|gt|gte) is not met (numeric)', async () => {
-    const page = await newSpecPage({
-      components: [PosSwitch],
-      html: `
-      <pos-switch>
-        <pos-case if-property="https://schema.org/name" every-value-lt="4">
-          <template>
-            <div>Not shown: ! 20 and 30 < 4</div>
-          </template>
-        </pos-case>
-        <pos-case if-property="https://schema.org/name" every-value-lte="4">
-          <template>
-            <div>Not shown: ! 20 and 30 <= 4</div>
-          </template>
-        </pos-case>
-        <pos-case if-property="https://schema.org/name" every-value-gte="100">
-          <template>
-            <div>Not shown: ! 20 and 30 >= 100</div>
-          </template>
-        </pos-case>
-        <pos-case if-property="https://schema.org/name" every-value-gt="100">
-          <template>
-            <div>Not shown: ! 20 and 30 > 100</div>
-          </template>
-        </pos-case>
-        <pos-case else>
-          <template>
-            <div>No conditions match</div>
-          </template>
-        </pos-case>
-      </pos-switch>`,
-    });
-    const observedRelations$ = new Subject<Relation[]>();
-    const observedLiterals$ = new Subject<Literal[]>();
-    const thing = {
-      uri: 'https://pod.example/resource',
-      observeLiterals: () => observedLiterals$,
-      observeRelations: () => observedRelations$,
-    };
-    page.rootInstance.receiveResource(thing);
-    observedLiterals$.next([{ predicate: 'https://schema.org/name', label: 'name', values: ['20', '30'] }]);
-    observedRelations$.next([]);
-    await page.waitForChanges();
-    expect(page.root?.innerHTML).toEqualHtml(`
-        <div>No conditions match</div>
-        `);
-  });
-
-  it('renders templates when property is absent (not if-property)', async () => {
-    const page = await newSpecPage({
-      components: [PosSwitch],
-      html: `
-      <pos-switch>
-        <pos-case not if-property="https://schema.org/description">
-          <template>
-            <div>Resource has no description</div>
-          </template>
-        </pos-case>
-        <pos-case if-property="https://schema.org/description">
-          <template>
-            <div>Should not render as description is not present</div>
-          </template>
-        </pos-case>
-      </pos-switch>`,
-    });
-    const observedRelations$ = new Subject<Relation[]>();
-    const observedLiterals$ = new Subject<Literal[]>();
-    const thing = {
-      uri: 'https://pod.example/resource',
-      observeRelations: () => observedRelations$,
-      observeLiterals: () => observedLiterals$,
-    };
-    page.rootInstance.receiveResource(thing);
-    observedLiterals$.next([]);
-    observedRelations$.next([]);
-    await page.waitForChanges();
-    expect(page.root?.innerHTML).toEqualHtml(`
-        <div>Resource has no description</div>
-        `);
-  });
-
-  it('renders templates when backward link is absent (not if-rev)', async () => {
-    const page = await newSpecPage({
-      components: [PosSwitch],
-      html: `
-      <pos-switch>
-        <pos-case not if-rev="https://schema.org/video">
-          <template>
-            <div>Resource is not a video object</div>
-          </template>
-        </pos-case>
-        <pos-case if-rev="https://schema.org/video">
-          <template>
-            <div>Should not render as video reverse relation is not present</div>
-          </template>
-        </pos-case>
-      </pos-switch>`,
-    });
-    const observedReverseRelations$ = new Subject<Relation[]>();
-    const thing = {
-      uri: 'https://pod.example/resource',
-      observeReverseRelations: () => observedReverseRelations$,
-    };
-    page.rootInstance.receiveResource(thing);
-    observedReverseRelations$.next([]);
-    await page.waitForChanges();
-    expect(page.root?.innerHTML).toEqualHtml(`
-        <div>Resource is not a video object</div>
-        `);
-  });
-
   it('resets and updates when resource is changed', async () => {
     const page = await newSpecPage({
       components: [PosSwitch],
@@ -781,132 +268,4 @@ describe('pos-switch', () => {
     await page.waitForChanges();
     expect(page.root?.innerText).toEqualText('Video.');
   });
-
-  it.each([
-    // literal + some-value-eq
-    {
-      conditions: 'if-property="https://schema.org/name" some-value-eq="the-name"',
-      observedLiterals: [
-        { predicate: 'https://schema.org/name', label: 'video', values: ['the-name', 'another-name'] },
-      ],
-      observedRelations: [],
-      observedReverseRelations: [],
-      expectedResult: 'matched',
-    },
-    {
-      conditions: 'if-property="https://schema.org/name" some-value-eq="the-name"',
-      observedLiterals: [{ predicate: 'https://schema.org/name', label: 'video', values: ['the-name'] }],
-      observedRelations: [],
-      observedReverseRelations: [],
-      expectedResult: 'matched',
-    },
-    {
-      conditions: 'not if-property="https://schema.org/name" some-value-eq="the-name"',
-      observedLiterals: [
-        { predicate: 'https://schema.org/name', label: 'video', values: ['the-name', 'another-name'] },
-      ],
-      observedRelations: [],
-      observedReverseRelations: [],
-      expectedResult: 'not matched',
-    },
-    {
-      conditions: 'not if-property="https://schema.org/name" some-value-eq="different-name"',
-      observedLiterals: [
-        { predicate: 'https://schema.org/name', label: 'video', values: ['the-name', 'another-name'] },
-      ],
-      observedRelations: [],
-      observedReverseRelations: [],
-      expectedResult: 'matched',
-    },
-    // literal + every-value-eq
-    {
-      conditions: 'if-property="https://schema.org/name" every-value-eq="the-name"',
-      observedLiterals: [
-        { predicate: 'https://schema.org/name', label: 'video', values: ['the-name', 'another-name'] },
-      ],
-      observedRelations: [],
-      observedReverseRelations: [],
-      expectedResult: 'not matched',
-    },
-    {
-      conditions: 'if-property="https://schema.org/name" every-value-eq="the-name"',
-      observedLiterals: [{ predicate: 'https://schema.org/name', label: 'video', values: ['the-name'] }],
-      observedRelations: [],
-      observedReverseRelations: [],
-      expectedResult: 'matched',
-    },
-    {
-      conditions: 'not if-property="https://schema.org/name" every-value-eq="the-name"',
-      observedLiterals: [
-        { predicate: 'https://schema.org/name', label: 'video', values: ['the-name', 'another-name'] },
-      ],
-      observedRelations: [],
-      observedReverseRelations: [],
-      expectedResult: 'matched',
-    },
-    // relation + some-value-eq
-    {
-      conditions: 'if-property="https://schema.org/video" some-value-eq="https://video.test/video-1"',
-      observedLiterals: [],
-      observedRelations: [
-        {
-          predicate: 'https://schema.org/video',
-          label: 'video',
-          uris: ['https://video.test/video-1', 'https://video.test/video-2'],
-        },
-      ],
-      observedReverseRelations: [],
-      expectedResult: 'matched',
-    },
-    {
-      conditions: 'not if-property="https://schema.org/video" some-value-eq="https://video.test/video-1"',
-      observedLiterals: [],
-      observedRelations: [
-        {
-          predicate: 'https://schema.org/video',
-          label: 'video',
-          uris: ['https://video.test/video-1', 'https://video.test/video-2'],
-        },
-      ],
-      observedReverseRelations: [],
-      expectedResult: 'not matched',
-    },
-  ])(
-    `renders templates if condition is met: $conditions `,
-    async ({ conditions, observedLiterals, observedRelations, observedReverseRelations, expectedResult }) => {
-      const page = await newSpecPage({
-        components: [PosSwitch],
-        html: `
-      <pos-switch>
-        <pos-case ${conditions}>
-          <template>
-            <div>Condition is matched</div>
-          </template>
-        </pos-case>
-        <pos-case else>
-          <template>
-            <div>Condition is not matched</div>
-          </template>
-        </pos-case>
-      </pos-switch>`,
-      });
-      const observedRelations$ = new Subject<Relation[]>();
-      const observedLiterals$ = new Subject<Literal[]>();
-      const observedReverseRelations$ = new Subject<Relation[]>();
-      const thing = {
-        uri: 'https://pod.example/resource',
-        observeRelations: () => observedRelations$,
-        observeLiterals: () => observedLiterals$,
-        observedReverseRelations: () => observedLiterals$,
-      };
-      page.rootInstance.receiveResource(thing);
-      observedLiterals$.next(observedLiterals);
-      observedRelations$.next(observedRelations);
-      observedReverseRelations$.next(observedReverseRelations);
-      await page.waitForChanges();
-      expect(page.root?.innerHTML).toEqualHtml(`
-        <div>Condition is ${expectedResult}</div>
-        `);
-    },
-  );
 });

--- a/elements/src/components/pos-switch/pos-switch.spec.tsx
+++ b/elements/src/components/pos-switch/pos-switch.spec.tsx
@@ -68,10 +68,11 @@ describe('pos-switch', () => {
     });
   });
 
-  it('renders matching condition templates, reactively', async () => {
-    const page = await newSpecPage({
-      components: [PosSwitch],
-      html: `
+  describe('reactive updating', () => {
+    it('renders matching condition templates, reactively', async () => {
+      const page = await newSpecPage({
+        components: [PosSwitch],
+        html: `
       <pos-switch>
         <pos-case if-typeof="http://schema.org/Recipe">
           <template>
@@ -89,23 +90,70 @@ describe('pos-switch', () => {
           </template>
         </pos-case>
       </pos-switch>`,
-    });
-    const observedTypes$ = new Subject<RdfType[]>();
-    const thing = {
-      observeTypes: () => observedTypes$,
-    } as unknown as Thing;
-    page.rootInstance.receiveResource(thing);
-    observedTypes$.next([
-      {
-        label: 'Recipe',
-        uri: 'http://schema.org/Recipe',
-      },
-    ]);
-    await page.waitForChanges();
-    expect(page.root?.innerHTML).toEqualHtml(`
+      });
+      const observedTypes$ = new Subject<RdfType[]>();
+      const thing = {
+        observeTypes: () => observedTypes$,
+      } as unknown as Thing;
+      page.rootInstance.receiveResource(thing);
+      observedTypes$.next([
+        {
+          label: 'Recipe',
+          uri: 'http://schema.org/Recipe',
+        },
+      ]);
+      await page.waitForChanges();
+      expect(page.root?.innerHTML).toEqualHtml(`
         <div>Recipe 1</div>
         <div>Recipe 2</div>
         `);
+    });
+
+    it('resets and updates when resource is changed', async () => {
+      const page = await newSpecPage({
+        components: [PosSwitch],
+        html: `
+      <pos-switch>
+        <pos-case if-typeof="http://schema.org/Recipe">
+          <template>Recipe.</template>
+        </pos-case>
+        <pos-case if-typeof="http://schema.org/Video">
+          <template>Video.</template>
+        </pos-case>
+      </pos-switch>`,
+      });
+      const observedTypes$ = new Subject<RdfType[]>();
+      const thing = {
+        uri: 'https://pod.example/recipe1',
+        observeTypes: () => observedTypes$,
+      };
+      page.rootInstance.receiveResource(thing);
+      observedTypes$.next([
+        {
+          label: 'Recipe',
+          uri: 'http://schema.org/Recipe',
+        },
+      ]);
+      await page.waitForChanges();
+      expect(page.root?.innerText).toEqualText('Recipe.');
+      // new thing
+      const observedTypes2$ = new Subject<RdfType[]>();
+      const thing2 = {
+        uri: 'https://pod.example/video1',
+        observeTypes: () => observedTypes2$,
+      };
+      page.rootInstance.receiveResource(thing2);
+      await page.waitForChanges();
+      expect(page.root?.innerText).toEqualText('');
+      observedTypes2$.next([
+        {
+          label: 'Video',
+          uri: 'http://schema.org/Video',
+        },
+      ]);
+      await page.waitForChanges();
+      expect(page.root?.innerText).toEqualText('Video.');
+    });
   });
 
   describe('if-else logic', () => {
@@ -221,51 +269,5 @@ describe('pos-switch', () => {
         <div>Image.</div>
         <div>Recipe list.</div>
         `);
-  });
-
-  it('resets and updates when resource is changed', async () => {
-    const page = await newSpecPage({
-      components: [PosSwitch],
-      html: `
-      <pos-switch>
-        <pos-case if-typeof="http://schema.org/Recipe">
-          <template>Recipe.</template>
-        </pos-case>
-        <pos-case if-typeof="http://schema.org/Video">
-          <template>Video.</template>
-        </pos-case>
-      </pos-switch>`,
-    });
-    const observedTypes$ = new Subject<RdfType[]>();
-    const thing = {
-      uri: 'https://pod.example/recipe1',
-      observeTypes: () => observedTypes$,
-    };
-    page.rootInstance.receiveResource(thing);
-    observedTypes$.next([
-      {
-        label: 'Recipe',
-        uri: 'http://schema.org/Recipe',
-      },
-    ]);
-    await page.waitForChanges();
-    expect(page.root?.innerText).toEqualText('Recipe.');
-    // new thing
-    const observedTypes2$ = new Subject<RdfType[]>();
-    const thing2 = {
-      uri: 'https://pod.example/video1',
-      observeTypes: () => observedTypes2$,
-    };
-    page.rootInstance.receiveResource(thing2);
-    await page.waitForChanges();
-    expect(page.root?.innerText).toEqualText('');
-    observedTypes2$.next([
-      {
-        label: 'Video',
-        uri: 'http://schema.org/Video',
-      },
-    ]);
-    await page.waitForChanges();
-    expect(page.root?.innerText).toEqualText('Video.');
   });
 });

--- a/elements/src/components/pos-switch/pos-switch.spec.tsx
+++ b/elements/src/components/pos-switch/pos-switch.spec.tsx
@@ -481,6 +481,102 @@ describe('pos-switch', () => {
         `);
   });
 
+  it('does not render templates when compareValue indicates that some-value-(lt|lte|gt|gte) is not met (string)', async () => {
+    const page = await newSpecPage({
+      components: [PosSwitch],
+      html: `
+      <pos-switch>
+        <pos-case if-property="https://schema.org/name" some-value-lt="bravo">
+          <template>
+            <div>Not shown: ! bravo < bravo </div>
+          </template>
+        </pos-case>
+        <pos-case if-property="https://schema.org/name" some-value-lte="alpha">
+          <template>
+            <div>Not shown: ! bravo <= alpha</div>
+          </template>
+        </pos-case>
+        <pos-case if-property="https://schema.org/name" some-value-gte="charlie">
+          <template>
+            <div>Not shown: ! bravo >= charlie</div>
+          </template>
+        </pos-case>
+        <pos-case if-property="https://schema.org/name" some-value-gt="bravo">
+          <template>
+            <div>Not shown: ! bravo > bravo</div>
+          </template>
+        </pos-case>
+        <pos-case else>
+          <template>
+            <div>No conditions match</div>
+          </template>
+        </pos-case>
+      </pos-switch>`,
+    });
+    const observedRelations$ = new Subject<Relation[]>();
+    const observedLiterals$ = new Subject<Literal[]>();
+    const thing = {
+      uri: 'https://pod.example/resource',
+      observeLiterals: () => observedLiterals$,
+      observeRelations: () => observedRelations$,
+    };
+    page.rootInstance.receiveResource(thing);
+    observedLiterals$.next([{ predicate: 'https://schema.org/name', label: 'name', values: ['bravo'] }]);
+    observedRelations$.next([]);
+    await page.waitForChanges();
+    expect(page.root?.innerHTML).toEqualHtml(`
+        <div>No conditions match</div>
+        `);
+  });
+
+  it('does not render templates when compareValue indicates that every-value-(lt|lte|gt|gte) is not met (string)', async () => {
+    const page = await newSpecPage({
+      components: [PosSwitch],
+      html: `
+      <pos-switch>
+        <pos-case if-property="https://schema.org/name" every-value-lt="bravo">
+          <template>
+            <div>Not shown: ! bravo and charlie < bravo </div>
+          </template>
+        </pos-case>
+        <pos-case if-property="https://schema.org/name" every-value-lte="bravo">
+          <template>
+            <div>Not shown: ! bravo and charlie <= bravo</div>
+          </template>
+        </pos-case>
+        <pos-case if-property="https://schema.org/name" every-value-gte="charlie">
+          <template>
+            <div>Not shown: ! bravo and charlie >=  charlie</div>
+          </template>
+        </pos-case>
+        <pos-case if-property="https://schema.org/name" every-value-gt="charlie">
+          <template>
+            <div>Not shown: ! bravo and charlie >  charlie</div>
+          </template>
+        </pos-case>
+        <pos-case else>
+          <template>
+            <div>No conditions match</div>
+          </template>
+        </pos-case>
+      </pos-switch>`,
+    });
+    const observedRelations$ = new Subject<Relation[]>();
+    const observedLiterals$ = new Subject<Literal[]>();
+    const thing = {
+      uri: 'https://pod.example/resource',
+      observeLiterals: () => observedLiterals$,
+      observeRelations: () => observedRelations$,
+    };
+    page.rootInstance.receiveResource(thing);
+    observedLiterals$.next([{ predicate: 'https://schema.org/name', label: 'name', values: ['bravo', 'charlie'] }]);
+    observedRelations$.next([]);
+    await page.waitForChanges();
+    expect(page.root?.innerHTML).toEqualHtml(`
+        <div>No conditions match</div>
+        `);
+  });
+
   it('resets and updates when resource is changed', async () => {
     const page = await newSpecPage({
       components: [PosSwitch],

--- a/elements/src/components/pos-switch/pos-switch.spec.tsx
+++ b/elements/src/components/pos-switch/pos-switch.spec.tsx
@@ -783,6 +783,69 @@ describe('pos-switch', () => {
   });
 
   it.each([
+    // literal + some-value-eq
+    {
+      conditions: 'if-property="https://schema.org/name" some-value-eq="the-name"',
+      observedLiterals: [
+        { predicate: 'https://schema.org/name', label: 'video', values: ['the-name', 'another-name'] },
+      ],
+      observedRelations: [],
+      observedReverseRelations: [],
+      expectedResult: 'matched',
+    },
+    {
+      conditions: 'if-property="https://schema.org/name" some-value-eq="the-name"',
+      observedLiterals: [{ predicate: 'https://schema.org/name', label: 'video', values: ['the-name'] }],
+      observedRelations: [],
+      observedReverseRelations: [],
+      expectedResult: 'matched',
+    },
+    {
+      conditions: 'not if-property="https://schema.org/name" some-value-eq="the-name"',
+      observedLiterals: [
+        { predicate: 'https://schema.org/name', label: 'video', values: ['the-name', 'another-name'] },
+      ],
+      observedRelations: [],
+      observedReverseRelations: [],
+      expectedResult: 'not matched',
+    },
+    // TODO fails, but should match: there is some value that is not "different-name"
+    // {
+    //   conditions: 'not if-property="https://schema.org/name" some-value-eq="different-name"',
+    //   observedLiterals: [
+    //     { predicate: 'https://schema.org/name', label: 'video', values: ['the-name', 'another-name'] },
+    //   ],
+    //   observedRelations: [],
+    //   observedReverseRelations: [],
+    //   expectedResult: 'matched',
+    // },
+    // literal + every-value-eq
+    {
+      conditions: 'if-property="https://schema.org/name" every-value-eq="the-name"',
+      observedLiterals: [
+        { predicate: 'https://schema.org/name', label: 'video', values: ['the-name', 'another-name'] },
+      ],
+      observedRelations: [],
+      observedReverseRelations: [],
+      expectedResult: 'not matched',
+    },
+    {
+      conditions: 'if-property="https://schema.org/name" every-value-eq="the-name"',
+      observedLiterals: [{ predicate: 'https://schema.org/name', label: 'video', values: ['the-name'] }],
+      observedRelations: [],
+      observedReverseRelations: [],
+      expectedResult: 'matched',
+    },
+    // TODO fails, but should match: not every value is "the-name"
+    // {
+    //   conditions: 'not if-property="https://schema.org/name" every-value-eq="the-name"',
+    //   observedLiterals: [
+    //     { predicate: 'https://schema.org/name', label: 'video', values: ['the-name', 'another-name'] },
+    //   ],
+    //   observedRelations: [],
+    //   observedReverseRelations: [],
+    //   expectedResult: 'matched',
+    // },
     // relation + some-value-eq
     {
       conditions: 'if-property="https://schema.org/video" some-value-eq="https://video.test/video-1"',
@@ -807,25 +870,6 @@ describe('pos-switch', () => {
           uris: ['https://video.test/video-1', 'https://video.test/video-2'],
         },
       ],
-      observedReverseRelations: [],
-      expectedResult: 'not matched',
-    },
-    // literal + some-value-eq
-    {
-      conditions: 'if-property="https://schema.org/name" some-value-eq="the-name"',
-      observedLiterals: [
-        { predicate: 'https://schema.org/name', label: 'video', values: ['the-name', 'another-name'] },
-      ],
-      observedRelations: [],
-      observedReverseRelations: [],
-      expectedResult: 'matched',
-    },
-    {
-      conditions: 'not if-property="https://schema.org/name" some-value-eq="the-name"',
-      observedLiterals: [
-        { predicate: 'https://schema.org/name', label: 'video', values: ['the-name', 'another-name'] },
-      ],
-      observedRelations: [],
       observedReverseRelations: [],
       expectedResult: 'not matched',
     },

--- a/elements/src/components/pos-switch/pos-switch.test.spec.tsx
+++ b/elements/src/components/pos-switch/pos-switch.test.spec.tsx
@@ -756,6 +756,99 @@ describe('pos-switch', () => {
 
     // TODO evaluating values of property with multiple strings
 
+    describe('evaluating values of property (single number)', () => {
+      /*
+        40 possible combinations:
+        
+        - Condition: (some|every)-(eq|lt|lte|gt|gte)
+        - Modifier: negation
+        - Evaluation state: matched, not matched
+
+        We test three values (60 combinations) matching eq, lt, or gt
+        The values are selected so that string comparison is insufficient.
+        There is no difference between some and every with a single number.
+        */
+      let testCases = [];
+      for (let semantics of ['some', 'every']) {
+        for (let operator of ['eq', 'gt', 'gte', 'lt', 'lte']) {
+          for (let negation of [true, false]) {
+            for (let stringValue of ['3', '20', '100']) {
+              const cmp = Number(stringValue) - 20;
+              let matches;
+              switch (operator) {
+                case 'eq':
+                  matches = cmp === 0;
+                  break;
+                case 'gt':
+                  matches = cmp > 0;
+                  break;
+                case 'gte':
+                  matches = cmp >= 0;
+                  break;
+                case 'lt':
+                  matches = cmp < 0;
+                  break;
+                case 'lte':
+                  matches = cmp <= 0;
+                  break;
+              }
+              matches = negation ? !matches : matches;
+              const result = matches ? 'matched' : 'not matched';
+              const not = negation ? 'not' : '';
+              testCases.push({
+                conditions: `if-property="https://schema.org/value" ${not} ${semantics}-value-${operator}="20"`,
+                stringValue: stringValue,
+                expectedResult: result,
+              });
+            }
+          }
+        }
+      }
+      expect(testCases.filter(testCase => testCase.expectedResult == 'matched').length).toEqual(30);
+      expect(testCases.filter(testCase => testCase.expectedResult == 'not matched').length).toEqual(30);
+
+      it.each(testCases)(
+        `renders templates if condition is met: $conditions for $resource `,
+        async ({ conditions, stringValue, expectedResult }) => {
+          const page = await newSpecPage({
+            components: [PosSwitch],
+            html: `
+      <pos-switch>
+        <pos-case ${conditions}>
+          <template>
+            <div>Condition is matched</div>
+          </template>
+        </pos-case>
+        <pos-case else>
+          <template>
+            <div>Condition is not matched</div>
+          </template>
+        </pos-case>
+      </pos-switch>`,
+          });
+          const observedRelations$ = new Subject<Relation[]>();
+          const observedLiterals$ = new Subject<Literal[]>();
+          const observedReverseRelations$ = new Subject<Relation[]>();
+          const thing = {
+            uri: 'https://pod.example/resource',
+            observeRelations: () => observedRelations$,
+            observeLiterals: () => observedLiterals$,
+            observeReverseRelations: () => observedReverseRelations$,
+          };
+          page.rootInstance.receiveResource(thing);
+          observedLiterals$.next([{ predicate: 'https://schema.org/value', label: 'value', values: [stringValue] }]);
+          observedRelations$.next([]);
+          observedReverseRelations$.next([]);
+          await page.waitForChanges();
+          expect(page.root?.innerHTML).toEqualHtml(`
+        <div>Condition is ${expectedResult}</div>
+        `);
+        },
+      );
+    });
+
+    // TODO evaluating values of property with multiple numbers
+
     it('renders templates if forward link value condition is met (literal)', async () => {
       const page = await newSpecPage({
         components: [PosSwitch],
@@ -871,54 +964,6 @@ describe('pos-switch', () => {
       };
       page.rootInstance.receiveResource(thing);
       observedLiterals$.next([{ predicate: 'https://schema.org/name', label: 'name', values: ['bravo', 'charlie'] }]);
-      observedRelations$.next([]);
-      await page.waitForChanges();
-      expect(page.root?.innerHTML).toEqualHtml(`
-        <div>No conditions match</div>
-        `);
-    });
-
-    it('does not render templates when compareValue indicates that some-value-(lt|lte|gt|gte) is not met (numeric)', async () => {
-      const page = await newSpecPage({
-        components: [PosSwitch],
-        html: `
-      <pos-switch>
-        <pos-case if-property="https://schema.org/name" some-value-lt="3">
-          <template>
-            <div>Not shown: ! 20 < 3</div>
-          </template>
-        </pos-case>
-        <pos-case if-property="https://schema.org/name" some-value-lte="3">
-          <template>
-            <div>Not shown: ! 20 <= 3</div>
-          </template>
-        </pos-case>
-        <pos-case if-property="https://schema.org/name" some-value-gte="100">
-          <template>
-            <div>Not shown: ! 20 >= 100</div>
-          </template>
-        </pos-case>
-        <pos-case if-property="https://schema.org/name" some-value-gt="100">
-          <template>
-            <div>Not shown: ! 20 > 100</div>
-          </template>
-        </pos-case>
-        <pos-case else>
-          <template>
-            <div>No conditions match</div>
-          </template>
-        </pos-case>
-      </pos-switch>`,
-      });
-      const observedRelations$ = new Subject<Relation[]>();
-      const observedLiterals$ = new Subject<Literal[]>();
-      const thing = {
-        uri: 'https://pod.example/resource',
-        observeLiterals: () => observedLiterals$,
-        observeRelations: () => observedRelations$,
-      };
-      page.rootInstance.receiveResource(thing);
-      observedLiterals$.next([{ predicate: 'https://schema.org/name', label: 'name', values: ['20'] }]);
       observedRelations$.next([]);
       await page.waitForChanges();
       expect(page.root?.innerHTML).toEqualHtml(`

--- a/elements/src/components/pos-switch/pos-switch.test.spec.tsx
+++ b/elements/src/components/pos-switch/pos-switch.test.spec.tsx
@@ -1,0 +1,653 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { PosSwitch } from './pos-switch';
+import { Literal, RdfType, Relation, Thing } from '@pod-os/core';
+import { Subject } from 'rxjs';
+
+describe('pos-switch', () => {
+  describe('evaluation of caseElement conditions with test method ', () => {
+    it('renders matching condition with negation', async () => {
+      const page = await newSpecPage({
+        components: [PosSwitch],
+        html: `
+      <pos-switch>
+        <pos-case not if-typeof="http://schema.org/Video"><template><div>Not a Video</div></template></pos-case>
+      </pos-switch>`,
+      });
+      const observedTypes$ = new Subject<RdfType[]>();
+      const thing = {
+        observeTypes: () => observedTypes$,
+      } as unknown as Thing;
+      page.rootInstance.receiveResource(thing);
+      observedTypes$.next([
+        {
+          label: 'Recipe',
+          uri: 'http://schema.org/Recipe',
+        },
+      ]);
+      await page.waitForChanges();
+      expect(page.root?.innerHTML).toEqualHtml(`
+        <div>Not a Video</div>
+        `);
+    });
+
+    it('renders templates if a forward link is present (relation)', async () => {
+      const page = await newSpecPage({
+        components: [PosSwitch],
+        html: `
+      <pos-switch>
+        <pos-case if-property="https://schema.org/video">
+          <template>
+            <div>Resource has video</div>
+          </template>
+        </pos-case>
+        <pos-case if-property="https://schema.org/description">
+          <template>
+            <div>Should not render as schema:description is not present</div>
+          </template>
+        </pos-case>
+      </pos-switch>`,
+      });
+      const observedRelations$ = new Subject<Relation[]>();
+      const observedLiterals$ = new Subject<Literal[]>();
+
+      const thing = {
+        uri: 'https://pod.example/resource',
+        observeRelations: () => observedRelations$,
+        observeLiterals: () => observedLiterals$,
+      };
+      page.rootInstance.receiveResource(thing);
+      observedLiterals$.next([]);
+      observedRelations$.next([
+        { predicate: 'https://schema.org/video', label: 'video', uris: ['https://video.test/video-1'] },
+      ]);
+      await page.waitForChanges();
+      expect(page.root?.innerHTML).toEqualHtml(`
+        <div>Resource has video</div>
+        `);
+    });
+
+    it('renders templates if a forward link is present (literal)', async () => {
+      const page = await newSpecPage({
+        components: [PosSwitch],
+        html: `
+      <pos-switch>
+        <pos-case if-property="https://schema.org/name">
+          <template>
+            <div>Resource has a name</div>
+          </template>
+        </pos-case>
+      </pos-switch>`,
+      });
+      const observedRelations$ = new Subject<Relation[]>();
+      const observedLiterals$ = new Subject<Literal[]>();
+      const thing = {
+        uri: 'https://pod.example/resource',
+        observeRelations: () => observedRelations$,
+        observeLiterals: () => observedLiterals$,
+      };
+      page.rootInstance.receiveResource(thing);
+      observedRelations$.next([]);
+      observedLiterals$.next([{ predicate: 'https://schema.org/name', label: 'name', values: ['name'] }]);
+      await page.waitForChanges();
+      expect(page.root?.innerHTML).toEqualHtml(`
+        <div>Resource has a name</div>
+        `);
+    });
+
+    it('renders templates if a backward link is present', async () => {
+      const page = await newSpecPage({
+        components: [PosSwitch],
+        html: `
+      <pos-switch>
+        <pos-case if-rev="https://schema.org/video">
+          <template>
+            <div>Resource is video</div>
+          </template>
+        </pos-case>
+        <pos-case if-rev="https://schema.org/subjectOf">
+          <template>
+            <div>Should not render as resource is not object of schema:subjectOf</div>
+          </template>
+        </pos-case>
+      </pos-switch>`,
+      });
+      const observedReverseRelations$ = new Subject<Relation[]>();
+      const thing = {
+        uri: 'https://pod.example/resource',
+        observeReverseRelations: () => observedReverseRelations$,
+      };
+      page.rootInstance.receiveResource(thing);
+      observedReverseRelations$.next([
+        { predicate: 'https://schema.org/video', label: 'video', uris: ['https://video.test/video-1'] },
+      ]);
+      await page.waitForChanges();
+      expect(page.root?.innerHTML).toEqualHtml(`
+        <div>Resource is video</div>
+        `);
+    });
+
+    it('renders templates if forward link value condition is met (relation)', async () => {
+      const page = await newSpecPage({
+        components: [PosSwitch],
+        html: `
+      <pos-switch>
+        <pos-case if-property="https://schema.org/video" some-value-eq="https://video.test/video-1">
+          <template>
+            <div>Resource has video</div>
+          </template>
+        </pos-case>
+        <pos-case if-property="https://schema.org/video" some-value-eq="https://video.test/video-missing">
+          <template>
+            <div>Should not render as value condition is not met</div>
+          </template>
+        </pos-case>
+      </pos-switch>`,
+      });
+      const observedRelations$ = new Subject<Relation[]>();
+      const observedLiterals$ = new Subject<Literal[]>();
+      const thing = {
+        uri: 'https://pod.example/resource',
+        observeRelations: () => observedRelations$,
+        observeLiterals: () => observedLiterals$,
+      };
+      page.rootInstance.receiveResource(thing);
+      observedLiterals$.next([]);
+      observedRelations$.next([
+        { predicate: 'https://schema.org/video', label: 'video', uris: ['https://video.test/video-1'] },
+      ]);
+      await page.waitForChanges();
+      expect(page.root?.innerHTML).toEqualHtml(`
+        <div>Resource has video</div>
+        `);
+    });
+
+    it('renders templates if forward link value condition is met (literal)', async () => {
+      const page = await newSpecPage({
+        components: [PosSwitch],
+        html: `
+      <pos-switch>
+        <pos-case if-property="https://schema.org/name" some-value-eq="Video 1">
+          <template>
+            <div>Resource has name</div>
+          </template>
+        </pos-case>
+      </pos-switch>`,
+      });
+      const observedRelations$ = new Subject<Relation[]>();
+      const observedLiterals$ = new Subject<Literal[]>();
+      const thing = {
+        uri: 'https://pod.example/resource',
+        observeRelations: () => observedRelations$,
+        observeLiterals: () => observedLiterals$,
+      };
+      page.rootInstance.receiveResource(thing);
+      observedRelations$.next([
+        { predicate: 'https://schema.org/video', label: 'video', uris: ['https://video.test/video-1'] },
+      ]);
+      observedLiterals$.next([{ predicate: 'https://schema.org/name', label: 'name', values: ['Video 1'] }]);
+      await page.waitForChanges();
+      expect(page.root?.innerHTML).toEqualHtml(`
+        <div>Resource has name</div>
+        `);
+    });
+
+    it('renders templates if backward link value condition is met', async () => {
+      const page = await newSpecPage({
+        components: [PosSwitch],
+        html: `
+      <pos-switch>
+        <pos-case if-rev="https://schema.org/video" some-value-eq="https://video.test/video-1">
+          <template>
+            <div>Resource is video</div>
+          </template>
+        </pos-case>
+        <pos-case if-rev="https://schema.org/video" some-value-eq="https://video.test/video-missing">
+          <template>
+            <div>Should not render as condition is not met</div>
+          </template>
+        </pos-case>
+      </pos-switch>`,
+      });
+      const observedReverseRelations$ = new Subject<Relation[]>();
+      const thing = {
+        uri: 'https://pod.example/resource',
+        observeReverseRelations: () => observedReverseRelations$,
+      };
+      page.rootInstance.receiveResource(thing);
+      observedReverseRelations$.next([
+        { predicate: 'https://schema.org/video', label: 'video', uris: ['https://video.test/video-1'] },
+      ]);
+      await page.waitForChanges();
+      expect(page.root?.innerHTML).toEqualHtml(`
+        <div>Resource is video</div>
+        `);
+    });
+
+    it('does not render templates when compareValue indicates that (some|every)-value-eq is not met', async () => {
+      const page = await newSpecPage({
+        components: [PosSwitch],
+        html: `
+      <pos-switch>
+        <pos-case if-property="https://schema.org/video" some-value-eq="https://video.test/video-missing">
+          <template>
+            <div>some-value-eq not https://video.test/video-missing</div>
+          </template>
+        </pos-case>
+        <pos-case if-property="https://schema.org/video" every-value-eq="https://video.test/video-1">
+          <template>
+            <div>every-value-eq not https://video.test/video-1</div>
+          </template>
+        </pos-case>
+        <pos-case else>
+          <template>
+            <div>No conditions match</div>
+          </template>
+        </pos-case>
+      </pos-switch>`,
+      });
+      const observedRelations$ = new Subject<Relation[]>();
+      const observedLiterals$ = new Subject<Literal[]>();
+      const thing = {
+        uri: 'https://pod.example/resource',
+        observeLiterals: () => observedLiterals$,
+        observeRelations: () => observedRelations$,
+      };
+      page.rootInstance.receiveResource(thing);
+      observedLiterals$.next([]);
+      observedRelations$.next([
+        {
+          predicate: 'https://schema.org/video',
+          label: 'video',
+          uris: ['https://video.test/video-1', 'https://video.test/video-2'],
+        },
+      ]);
+      await page.waitForChanges();
+      expect(page.root?.innerHTML).toEqualHtml(`
+        <div>No conditions match</div>
+        `);
+    });
+
+    it('does not render templates when compareValue indicates that some-value-(lt|lte|gt|gte) is not met (string)', async () => {
+      const page = await newSpecPage({
+        components: [PosSwitch],
+        html: `
+      <pos-switch>
+        <pos-case if-property="https://schema.org/name" some-value-lt="bravo">
+          <template>
+            <div>Not shown: ! bravo < bravo </div>
+          </template>
+        </pos-case>
+        <pos-case if-property="https://schema.org/name" some-value-lte="alpha">
+          <template>
+            <div>Not shown: ! bravo <= alpha</div>
+          </template>
+        </pos-case>
+        <pos-case if-property="https://schema.org/name" some-value-gte="charlie">
+          <template>
+            <div>Not shown: ! bravo >= charlie</div>
+          </template>
+        </pos-case>
+        <pos-case if-property="https://schema.org/name" some-value-gt="bravo">
+          <template>
+            <div>Not shown: ! bravo > bravo</div>
+          </template>
+        </pos-case>
+        <pos-case else>
+          <template>
+            <div>No conditions match</div>
+          </template>
+        </pos-case>
+      </pos-switch>`,
+      });
+      const observedRelations$ = new Subject<Relation[]>();
+      const observedLiterals$ = new Subject<Literal[]>();
+      const thing = {
+        uri: 'https://pod.example/resource',
+        observeLiterals: () => observedLiterals$,
+        observeRelations: () => observedRelations$,
+      };
+      page.rootInstance.receiveResource(thing);
+      observedLiterals$.next([{ predicate: 'https://schema.org/name', label: 'name', values: ['bravo'] }]);
+      observedRelations$.next([]);
+      await page.waitForChanges();
+      expect(page.root?.innerHTML).toEqualHtml(`
+        <div>No conditions match</div>
+        `);
+    });
+
+    it('does not render templates when compareValue indicates that every-value-(lt|lte|gt|gte) is not met (string)', async () => {
+      const page = await newSpecPage({
+        components: [PosSwitch],
+        html: `
+      <pos-switch>
+        <pos-case if-property="https://schema.org/name" every-value-lt="bravo">
+          <template>
+            <div>Not shown: ! bravo and charlie < bravo </div>
+          </template>
+        </pos-case>
+        <pos-case if-property="https://schema.org/name" every-value-lte="bravo">
+          <template>
+            <div>Not shown: ! bravo and charlie <= bravo</div>
+          </template>
+        </pos-case>
+        <pos-case if-property="https://schema.org/name" every-value-gte="charlie">
+          <template>
+            <div>Not shown: ! bravo and charlie >=  charlie</div>
+          </template>
+        </pos-case>
+        <pos-case if-property="https://schema.org/name" every-value-gt="charlie">
+          <template>
+            <div>Not shown: ! bravo and charlie > charlie</div>
+          </template>
+        </pos-case>
+        <pos-case else>
+          <template>
+            <div>No conditions match</div>
+          </template>
+        </pos-case>
+      </pos-switch>`,
+      });
+      const observedRelations$ = new Subject<Relation[]>();
+      const observedLiterals$ = new Subject<Literal[]>();
+      const thing = {
+        uri: 'https://pod.example/resource',
+        observeLiterals: () => observedLiterals$,
+        observeRelations: () => observedRelations$,
+      };
+      page.rootInstance.receiveResource(thing);
+      observedLiterals$.next([{ predicate: 'https://schema.org/name', label: 'name', values: ['bravo', 'charlie'] }]);
+      observedRelations$.next([]);
+      await page.waitForChanges();
+      expect(page.root?.innerHTML).toEqualHtml(`
+        <div>No conditions match</div>
+        `);
+    });
+
+    it('does not render templates when compareValue indicates that some-value-(lt|lte|gt|gte) is not met (numeric)', async () => {
+      const page = await newSpecPage({
+        components: [PosSwitch],
+        html: `
+      <pos-switch>
+        <pos-case if-property="https://schema.org/name" some-value-lt="3">
+          <template>
+            <div>Not shown: ! 20 < 3</div>
+          </template>
+        </pos-case>
+        <pos-case if-property="https://schema.org/name" some-value-lte="3">
+          <template>
+            <div>Not shown: ! 20 <= 3</div>
+          </template>
+        </pos-case>
+        <pos-case if-property="https://schema.org/name" some-value-gte="100">
+          <template>
+            <div>Not shown: ! 20 >= 100</div>
+          </template>
+        </pos-case>
+        <pos-case if-property="https://schema.org/name" some-value-gt="100">
+          <template>
+            <div>Not shown: ! 20 > 100</div>
+          </template>
+        </pos-case>
+        <pos-case else>
+          <template>
+            <div>No conditions match</div>
+          </template>
+        </pos-case>
+      </pos-switch>`,
+      });
+      const observedRelations$ = new Subject<Relation[]>();
+      const observedLiterals$ = new Subject<Literal[]>();
+      const thing = {
+        uri: 'https://pod.example/resource',
+        observeLiterals: () => observedLiterals$,
+        observeRelations: () => observedRelations$,
+      };
+      page.rootInstance.receiveResource(thing);
+      observedLiterals$.next([{ predicate: 'https://schema.org/name', label: 'name', values: ['20'] }]);
+      observedRelations$.next([]);
+      await page.waitForChanges();
+      expect(page.root?.innerHTML).toEqualHtml(`
+        <div>No conditions match</div>
+        `);
+    });
+
+    it('does not render templates when compareValue indicates that every-value-(lt|lte|gt|gte) is not met (numeric)', async () => {
+      const page = await newSpecPage({
+        components: [PosSwitch],
+        html: `
+      <pos-switch>
+        <pos-case if-property="https://schema.org/name" every-value-lt="4">
+          <template>
+            <div>Not shown: ! 20 and 30 < 4</div>
+          </template>
+        </pos-case>
+        <pos-case if-property="https://schema.org/name" every-value-lte="4">
+          <template>
+            <div>Not shown: ! 20 and 30 <= 4</div>
+          </template>
+        </pos-case>
+        <pos-case if-property="https://schema.org/name" every-value-gte="100">
+          <template>
+            <div>Not shown: ! 20 and 30 >= 100</div>
+          </template>
+        </pos-case>
+        <pos-case if-property="https://schema.org/name" every-value-gt="100">
+          <template>
+            <div>Not shown: ! 20 and 30 > 100</div>
+          </template>
+        </pos-case>
+        <pos-case else>
+          <template>
+            <div>No conditions match</div>
+          </template>
+        </pos-case>
+      </pos-switch>`,
+      });
+      const observedRelations$ = new Subject<Relation[]>();
+      const observedLiterals$ = new Subject<Literal[]>();
+      const thing = {
+        uri: 'https://pod.example/resource',
+        observeLiterals: () => observedLiterals$,
+        observeRelations: () => observedRelations$,
+      };
+      page.rootInstance.receiveResource(thing);
+      observedLiterals$.next([{ predicate: 'https://schema.org/name', label: 'name', values: ['20', '30'] }]);
+      observedRelations$.next([]);
+      await page.waitForChanges();
+      expect(page.root?.innerHTML).toEqualHtml(`
+        <div>No conditions match</div>
+        `);
+    });
+
+    it('renders templates when property is absent (not if-property)', async () => {
+      const page = await newSpecPage({
+        components: [PosSwitch],
+        html: `
+      <pos-switch>
+        <pos-case not if-property="https://schema.org/description">
+          <template>
+            <div>Resource has no description</div>
+          </template>
+        </pos-case>
+        <pos-case if-property="https://schema.org/description">
+          <template>
+            <div>Should not render as description is not present</div>
+          </template>
+        </pos-case>
+      </pos-switch>`,
+      });
+      const observedRelations$ = new Subject<Relation[]>();
+      const observedLiterals$ = new Subject<Literal[]>();
+      const thing = {
+        uri: 'https://pod.example/resource',
+        observeRelations: () => observedRelations$,
+        observeLiterals: () => observedLiterals$,
+      };
+      page.rootInstance.receiveResource(thing);
+      observedLiterals$.next([]);
+      observedRelations$.next([]);
+      await page.waitForChanges();
+      expect(page.root?.innerHTML).toEqualHtml(`
+        <div>Resource has no description</div>
+        `);
+    });
+
+    it('renders templates when backward link is absent (not if-rev)', async () => {
+      const page = await newSpecPage({
+        components: [PosSwitch],
+        html: `
+      <pos-switch>
+        <pos-case not if-rev="https://schema.org/video">
+          <template>
+            <div>Resource is not a video object</div>
+          </template>
+        </pos-case>
+        <pos-case if-rev="https://schema.org/video">
+          <template>
+            <div>Should not render as video reverse relation is not present</div>
+          </template>
+        </pos-case>
+      </pos-switch>`,
+      });
+      const observedReverseRelations$ = new Subject<Relation[]>();
+      const thing = {
+        uri: 'https://pod.example/resource',
+        observeReverseRelations: () => observedReverseRelations$,
+      };
+      page.rootInstance.receiveResource(thing);
+      observedReverseRelations$.next([]);
+      await page.waitForChanges();
+      expect(page.root?.innerHTML).toEqualHtml(`
+        <div>Resource is not a video object</div>
+        `);
+    });
+
+    it.each([
+      // literal + some-value-eq
+      {
+        conditions: 'if-property="https://schema.org/name" some-value-eq="the-name"',
+        observedLiterals: [
+          { predicate: 'https://schema.org/name', label: 'video', values: ['the-name', 'another-name'] },
+        ],
+        observedRelations: [],
+        observedReverseRelations: [],
+        expectedResult: 'matched',
+      },
+      {
+        conditions: 'if-property="https://schema.org/name" some-value-eq="the-name"',
+        observedLiterals: [{ predicate: 'https://schema.org/name', label: 'video', values: ['the-name'] }],
+        observedRelations: [],
+        observedReverseRelations: [],
+        expectedResult: 'matched',
+      },
+      {
+        conditions: 'not if-property="https://schema.org/name" some-value-eq="the-name"',
+        observedLiterals: [
+          { predicate: 'https://schema.org/name', label: 'video', values: ['the-name', 'another-name'] },
+        ],
+        observedRelations: [],
+        observedReverseRelations: [],
+        expectedResult: 'not matched',
+      },
+      {
+        conditions: 'not if-property="https://schema.org/name" some-value-eq="different-name"',
+        observedLiterals: [
+          { predicate: 'https://schema.org/name', label: 'video', values: ['the-name', 'another-name'] },
+        ],
+        observedRelations: [],
+        observedReverseRelations: [],
+        expectedResult: 'matched',
+      },
+      // literal + every-value-eq
+      {
+        conditions: 'if-property="https://schema.org/name" every-value-eq="the-name"',
+        observedLiterals: [
+          { predicate: 'https://schema.org/name', label: 'video', values: ['the-name', 'another-name'] },
+        ],
+        observedRelations: [],
+        observedReverseRelations: [],
+        expectedResult: 'not matched',
+      },
+      {
+        conditions: 'if-property="https://schema.org/name" every-value-eq="the-name"',
+        observedLiterals: [{ predicate: 'https://schema.org/name', label: 'video', values: ['the-name'] }],
+        observedRelations: [],
+        observedReverseRelations: [],
+        expectedResult: 'matched',
+      },
+      {
+        conditions: 'not if-property="https://schema.org/name" every-value-eq="the-name"',
+        observedLiterals: [
+          { predicate: 'https://schema.org/name', label: 'video', values: ['the-name', 'another-name'] },
+        ],
+        observedRelations: [],
+        observedReverseRelations: [],
+        expectedResult: 'matched',
+      },
+      // relation + some-value-eq
+      {
+        conditions: 'if-property="https://schema.org/video" some-value-eq="https://video.test/video-1"',
+        observedLiterals: [],
+        observedRelations: [
+          {
+            predicate: 'https://schema.org/video',
+            label: 'video',
+            uris: ['https://video.test/video-1', 'https://video.test/video-2'],
+          },
+        ],
+        observedReverseRelations: [],
+        expectedResult: 'matched',
+      },
+      {
+        conditions: 'not if-property="https://schema.org/video" some-value-eq="https://video.test/video-1"',
+        observedLiterals: [],
+        observedRelations: [
+          {
+            predicate: 'https://schema.org/video',
+            label: 'video',
+            uris: ['https://video.test/video-1', 'https://video.test/video-2'],
+          },
+        ],
+        observedReverseRelations: [],
+        expectedResult: 'not matched',
+      },
+    ])(
+      `renders templates if condition is met: $conditions `,
+      async ({ conditions, observedLiterals, observedRelations, observedReverseRelations, expectedResult }) => {
+        const page = await newSpecPage({
+          components: [PosSwitch],
+          html: `
+      <pos-switch>
+        <pos-case ${conditions}>
+          <template>
+            <div>Condition is matched</div>
+          </template>
+        </pos-case>
+        <pos-case else>
+          <template>
+            <div>Condition is not matched</div>
+          </template>
+        </pos-case>
+      </pos-switch>`,
+        });
+        const observedRelations$ = new Subject<Relation[]>();
+        const observedLiterals$ = new Subject<Literal[]>();
+        const observedReverseRelations$ = new Subject<Relation[]>();
+        const thing = {
+          uri: 'https://pod.example/resource',
+          observeRelations: () => observedRelations$,
+          observeLiterals: () => observedLiterals$,
+          observedReverseRelations: () => observedLiterals$,
+        };
+        page.rootInstance.receiveResource(thing);
+        observedLiterals$.next(observedLiterals);
+        observedRelations$.next(observedRelations);
+        observedReverseRelations$.next(observedReverseRelations);
+        await page.waitForChanges();
+        expect(page.root?.innerHTML).toEqualHtml(`
+        <div>Condition is ${expectedResult}</div>
+        `);
+      },
+    );
+  });
+});

--- a/elements/src/components/pos-switch/pos-switch.test.spec.tsx
+++ b/elements/src/components/pos-switch/pos-switch.test.spec.tsx
@@ -11,42 +11,92 @@ describe('pos-switch', () => {
        - Condition: present, (some|every)-(eq|lt|lte|gt|gte)
          - Modifier: negation
        - Values: relation (URI), string literal, numeric literal
-       - Data state: matched, not matched
+       - Data state: single value present, no value present, other value present, multiple values present
+       - Evaluation state: matched, not matched
     */
     describe('if-typeof', () => {
-      // Possible combinations:
-      // Condition: present, not present
-      // Data state: matched, not matched
-      // N.B. Does not take values
+      /*
+       12 theoretical combinations:
+
+       - Condition: present, not present
+       - Data state: single value present, no value present, multiple values present
+       - Evaluation state: matched, not matched
+
+       10 possible after removing:
+       - Present - no value - matched
+       - Not present - no value - not matched
+       */
+      const RecipeType = {
+        label: 'Recipe',
+        uri: 'http://schema.org/Recipe',
+      };
+      const VideoType = {
+        label: 'Video',
+        uri: 'http://schema.org/Video',
+      };
+      const EventType = {
+        label: 'Event',
+        uri: 'http://schema.org/Event',
+      };
       it.each([
+        // Present
+        // Single value
         {
           conditions: 'if-typeof="http://schema.org/Recipe"',
-          observedTypes: [
-            {
-              label: 'Recipe',
-              uri: 'http://schema.org/Recipe',
-            },
-          ],
+          observedTypes: [RecipeType],
           expectedResult: 'matched',
         },
         {
-          conditions: 'not if-typeof="http://schema.org/Recipe"',
-          observedTypes: [],
-          expectedResult: 'matched',
+          conditions: 'if-typeof="http://schema.org/Recipe"',
+          observedTypes: [VideoType],
+          expectedResult: 'not matched',
         },
+        // No value
+        // Matched case does not exist
         {
           conditions: 'if-typeof="http://schema.org/Recipe"',
           observedTypes: [],
           expectedResult: 'not matched',
         },
+        // Multiple values
+        {
+          conditions: 'if-typeof="http://schema.org/Recipe"',
+          observedTypes: [RecipeType, VideoType],
+          expectedResult: 'matched',
+        },
+        {
+          conditions: 'if-typeof="http://schema.org/Recipe"',
+          observedTypes: [VideoType, EventType],
+          expectedResult: 'not matched',
+        },
+        // Not present
+        // Single value
         {
           conditions: 'not if-typeof="http://schema.org/Recipe"',
-          observedTypes: [
-            {
-              label: 'Recipe',
-              uri: 'http://schema.org/Recipe',
-            },
-          ],
+          observedTypes: [VideoType],
+          expectedResult: 'matched',
+        },
+        {
+          conditions: 'not if-typeof="http://schema.org/Recipe"',
+          observedTypes: [RecipeType],
+          expectedResult: 'not matched',
+        },
+        // No value
+        // Not matched case does not exist
+        {
+          conditions: 'not if-typeof="http://schema.org/Recipe"',
+          observedTypes: [],
+          expectedResult: 'matched',
+        },
+        // Multiple values
+        {
+          conditions: 'not if-typeof="http://schema.org/Recipe"',
+          observedTypes: [VideoType, EventType],
+          expectedResult: 'matched',
+        },
+        {
+          conditions: 'not if-typeof="http://schema.org/Recipe"',
+          observedTypes: [RecipeType, VideoType],
           expectedResult: 'not matched',
         },
       ])(

--- a/elements/src/components/pos-switch/pos-switch.test.spec.tsx
+++ b/elements/src/components/pos-switch/pos-switch.test.spec.tsx
@@ -664,6 +664,98 @@ describe('pos-switch', () => {
 
     // TODO evaluating values of property and rev with multiple relations
 
+    describe('evaluating values of property (single strings)', () => {
+      /*
+        40 possible combinations:
+        
+        - Condition: (some|every)-(eq|lt|lte|gt|gte)
+        - Modifier: negation
+        - Evaluation state: matched, not matched
+
+        We test three resource values (60 combinations) matching eq, lt, or gt
+        There is no difference between some and every with a single relation.
+        */
+      let testCases = [];
+      for (let semantics of ['some', 'every']) {
+        for (let operator of ['eq', 'gt', 'gte', 'lt', 'lte']) {
+          for (let negation of [true, false]) {
+            for (let stringValue of ['a', 'b', 'c']) {
+              const cmp = stringValue.localeCompare('b');
+              let matches;
+              switch (operator) {
+                case 'eq':
+                  matches = cmp === 0;
+                  break;
+                case 'gt':
+                  matches = cmp > 0;
+                  break;
+                case 'gte':
+                  matches = cmp >= 0;
+                  break;
+                case 'lt':
+                  matches = cmp < 0;
+                  break;
+                case 'lte':
+                  matches = cmp <= 0;
+                  break;
+              }
+              matches = negation ? !matches : matches;
+              const result = matches ? 'matched' : 'not matched';
+              const not = negation ? 'not' : '';
+              testCases.push({
+                conditions: `if-property="https://schema.org/name" ${not} ${semantics}-value-${operator}="b"`,
+                stringValue: stringValue,
+                expectedResult: result,
+              });
+            }
+          }
+        }
+      }
+      expect(testCases.filter(testCase => testCase.expectedResult == 'matched').length).toEqual(30);
+      expect(testCases.filter(testCase => testCase.expectedResult == 'not matched').length).toEqual(30);
+
+      it.each(testCases)(
+        `renders templates if condition is met: $conditions for $resource `,
+        async ({ conditions, stringValue, expectedResult }) => {
+          const page = await newSpecPage({
+            components: [PosSwitch],
+            html: `
+      <pos-switch>
+        <pos-case ${conditions}>
+          <template>
+            <div>Condition is matched</div>
+          </template>
+        </pos-case>
+        <pos-case else>
+          <template>
+            <div>Condition is not matched</div>
+          </template>
+        </pos-case>
+      </pos-switch>`,
+          });
+          const observedRelations$ = new Subject<Relation[]>();
+          const observedLiterals$ = new Subject<Literal[]>();
+          const observedReverseRelations$ = new Subject<Relation[]>();
+          const thing = {
+            uri: 'https://pod.example/resource',
+            observeRelations: () => observedRelations$,
+            observeLiterals: () => observedLiterals$,
+            observeReverseRelations: () => observedReverseRelations$,
+          };
+          page.rootInstance.receiveResource(thing);
+          observedLiterals$.next([{ predicate: 'https://schema.org/name', label: 'name', values: [stringValue] }]);
+          observedRelations$.next([]);
+          observedReverseRelations$.next([]);
+          await page.waitForChanges();
+          expect(page.root?.innerHTML).toEqualHtml(`
+        <div>Condition is ${expectedResult}</div>
+        `);
+        },
+      );
+    });
+
+    // TODO evaluating values of property with multiple strings
+
     it('renders templates if forward link value condition is met (literal)', async () => {
       const page = await newSpecPage({
         components: [PosSwitch],
@@ -732,54 +824,6 @@ describe('pos-switch', () => {
           uris: ['https://video.test/video-1', 'https://video.test/video-2'],
         },
       ]);
-      await page.waitForChanges();
-      expect(page.root?.innerHTML).toEqualHtml(`
-        <div>No conditions match</div>
-        `);
-    });
-
-    it('does not render templates when compareValue indicates that some-value-(lt|lte|gt|gte) is not met (string)', async () => {
-      const page = await newSpecPage({
-        components: [PosSwitch],
-        html: `
-      <pos-switch>
-        <pos-case if-property="https://schema.org/name" some-value-lt="bravo">
-          <template>
-            <div>Not shown: ! bravo < bravo </div>
-          </template>
-        </pos-case>
-        <pos-case if-property="https://schema.org/name" some-value-lte="alpha">
-          <template>
-            <div>Not shown: ! bravo <= alpha</div>
-          </template>
-        </pos-case>
-        <pos-case if-property="https://schema.org/name" some-value-gte="charlie">
-          <template>
-            <div>Not shown: ! bravo >= charlie</div>
-          </template>
-        </pos-case>
-        <pos-case if-property="https://schema.org/name" some-value-gt="bravo">
-          <template>
-            <div>Not shown: ! bravo > bravo</div>
-          </template>
-        </pos-case>
-        <pos-case else>
-          <template>
-            <div>No conditions match</div>
-          </template>
-        </pos-case>
-      </pos-switch>`,
-      });
-      const observedRelations$ = new Subject<Relation[]>();
-      const observedLiterals$ = new Subject<Literal[]>();
-      const thing = {
-        uri: 'https://pod.example/resource',
-        observeLiterals: () => observedLiterals$,
-        observeRelations: () => observedRelations$,
-      };
-      page.rootInstance.receiveResource(thing);
-      observedLiterals$.next([{ predicate: 'https://schema.org/name', label: 'name', values: ['bravo'] }]);
-      observedRelations$.next([]);
       await page.waitForChanges();
       expect(page.root?.innerHTML).toEqualHtml(`
         <div>No conditions match</div>

--- a/elements/src/components/pos-switch/pos-switch.test.spec.tsx
+++ b/elements/src/components/pos-switch/pos-switch.test.spec.tsx
@@ -11,7 +11,7 @@ describe('pos-switch', () => {
        - Condition: present, (some|every)-(eq|lt|lte|gt|gte)
          - Modifier: negation
        - Values: relation (URI), string literal, numeric literal
-       - Data state: single value present, no value present, other value present, multiple values present
+       - Data state: single value present, no value present, multiple values present
        - Evaluation state: matched, not matched
     */
     describe('if-typeof', () => {
@@ -133,68 +133,228 @@ describe('pos-switch', () => {
       );
     });
 
-    it('renders templates if a forward link is present (relation)', async () => {
-      const page = await newSpecPage({
-        components: [PosSwitch],
-        html: `
+    describe('if-property presence/absence', () => {
+      /*
+      24 theoretical combinations:
+
+      - Condition: present, not present
+      - Data state: single value present, no value present, multiple values present
+      - Values: relation, literal
+      - Evaluation state: matched, not matched
+
+      20 possible after removing:
+
+      - present - no value - relation - matched
+      - present - no value - literal - matched
+      - not present - no value - relation - not matched
+      - not present - no value - literal - not matched
+    */
+      const LinkedVideo = {
+        predicate: 'https://schema.org/video',
+        label: 'video',
+        uris: ['https://video.test/video-1'],
+      };
+      const LinkedRecipe = {
+        predicate: 'https://schema.org/recipe',
+        label: 'recipe',
+        uris: ['https://recipe.test/recipe-1'],
+      };
+      const LinkedEvent = {
+        predicate: 'https://schema.org/event',
+        label: 'event',
+        uris: ['https://event.test/event-1'],
+      };
+      const VideoName = { predicate: 'https://schema.org/name', label: 'name', values: ['the-name'] };
+      const VideoAlternateName = {
+        predicate: 'https://schema.org/alternateName',
+        label: 'alternate name',
+        values: ['alt-name'],
+      };
+      const VideoDescription = {
+        predicate: 'https://schema.org/description',
+        label: 'description',
+        values: ['the-description'],
+      };
+      it.each([
+        // Present
+        // Single value
+        // Relation
+        {
+          conditions: 'if-property="https://schema.org/video"',
+          observedLiterals: [],
+          observedRelations: [LinkedVideo],
+          expectedResult: 'matched',
+        },
+        {
+          conditions: 'if-property="https://schema.org/video"',
+          observedLiterals: [],
+          observedRelations: [LinkedRecipe],
+          expectedResult: 'not matched',
+        },
+        // Literal
+        {
+          conditions: 'if-property="https://schema.org/name"',
+          observedLiterals: [VideoName],
+          observedRelations: [],
+          expectedResult: 'matched',
+        },
+        {
+          conditions: 'if-property="https://schema.org/name"',
+          observedLiterals: [VideoDescription],
+          observedRelations: [],
+          expectedResult: 'not matched',
+        },
+        // No value
+        // Relation
+        // Matched not possible
+        {
+          conditions: 'if-property="https://schema.org/video"',
+          observedLiterals: [],
+          observedRelations: [],
+          expectedResult: 'not matched',
+        },
+        // Literal
+        // Matched not possible
+        {
+          conditions: 'if-property="https://schema.org/name"',
+          observedLiterals: [],
+          observedRelations: [],
+          expectedResult: 'not matched',
+        },
+        // Multiple values
+        // Relation
+        {
+          conditions: 'if-property="https://schema.org/video"',
+          observedLiterals: [],
+          observedRelations: [LinkedVideo, LinkedRecipe],
+          expectedResult: 'matched',
+        },
+        {
+          conditions: 'if-property="https://schema.org/video"',
+          observedLiterals: [],
+          observedRelations: [LinkedRecipe, LinkedEvent],
+          expectedResult: 'not matched',
+        },
+        // Literal
+        {
+          conditions: 'if-property="https://schema.org/name"',
+          observedLiterals: [VideoName, VideoDescription],
+          observedRelations: [],
+          expectedResult: 'matched',
+        },
+        {
+          conditions: 'if-property="https://schema.org/name"',
+          observedLiterals: [VideoDescription, VideoAlternateName],
+          observedRelations: [],
+          expectedResult: 'not matched',
+        },
+        // Not present
+        // Single value
+        // Relation
+        {
+          conditions: 'not if-property="https://schema.org/video"',
+          observedLiterals: [],
+          observedRelations: [LinkedRecipe],
+          expectedResult: 'matched',
+        },
+        {
+          conditions: 'not if-property="https://schema.org/video"',
+          observedLiterals: [],
+          observedRelations: [LinkedVideo],
+          expectedResult: 'not matched',
+        },
+        // Literal
+        {
+          conditions: 'not if-property="https://schema.org/name"',
+          observedLiterals: [VideoDescription],
+          observedRelations: [],
+          expectedResult: 'matched',
+        },
+        {
+          conditions: 'not if-property="https://schema.org/name"',
+          observedLiterals: [VideoName],
+          observedRelations: [],
+          expectedResult: 'not matched',
+        },
+        // No value
+        // Relation
+        // Not matched not possible
+        {
+          conditions: 'not if-property="https://schema.org/video"',
+          observedLiterals: [],
+          observedRelations: [],
+          expectedResult: 'matched',
+        },
+        // Literal
+        // Not matched not possible
+        {
+          conditions: 'not if-property="https://schema.org/name"',
+          observedLiterals: [],
+          observedRelations: [],
+          expectedResult: 'matched',
+        },
+        // Multiple values
+        // Relation
+        {
+          conditions: 'not if-property="https://schema.org/video"',
+          observedLiterals: [],
+          observedRelations: [LinkedRecipe, LinkedEvent],
+          expectedResult: 'matched',
+        },
+        {
+          conditions: 'not if-property="https://schema.org/video"',
+          observedLiterals: [],
+          observedRelations: [LinkedVideo, LinkedEvent],
+          expectedResult: 'not matched',
+        },
+        // Literal
+        {
+          conditions: 'not if-property="https://schema.org/name"',
+          observedLiterals: [VideoDescription, VideoAlternateName],
+          observedRelations: [],
+          expectedResult: 'matched',
+        },
+        {
+          conditions: 'not if-property="https://schema.org/name"',
+          observedLiterals: [VideoName, VideoDescription],
+          observedRelations: [],
+          expectedResult: 'not matched',
+        },
+      ])(
+        `renders templates if condition is met: $conditions `,
+        async ({ conditions, observedLiterals, observedRelations, expectedResult }) => {
+          const page = await newSpecPage({
+            components: [PosSwitch],
+            html: `
       <pos-switch>
-        <pos-case if-property="https://schema.org/video">
+        <pos-case ${conditions}>
           <template>
-            <div>Resource has video</div>
+            <div>Condition is matched</div>
           </template>
         </pos-case>
-        <pos-case if-property="https://schema.org/description">
+        <pos-case else>
           <template>
-            <div>Should not render as schema:description is not present</div>
+            <div>Condition is not matched</div>
           </template>
         </pos-case>
       </pos-switch>`,
-      });
-      const observedRelations$ = new Subject<Relation[]>();
-      const observedLiterals$ = new Subject<Literal[]>();
-
-      const thing = {
-        uri: 'https://pod.example/resource',
-        observeRelations: () => observedRelations$,
-        observeLiterals: () => observedLiterals$,
-      };
-      page.rootInstance.receiveResource(thing);
-      observedLiterals$.next([]);
-      observedRelations$.next([
-        { predicate: 'https://schema.org/video', label: 'video', uris: ['https://video.test/video-1'] },
-      ]);
-      await page.waitForChanges();
-      expect(page.root?.innerHTML).toEqualHtml(`
-        <div>Resource has video</div>
+          });
+          const observedRelations$ = new Subject<Relation[]>();
+          const observedLiterals$ = new Subject<Literal[]>();
+          const thing = {
+            uri: 'https://pod.example/resource',
+            observeRelations: () => observedRelations$,
+            observeLiterals: () => observedLiterals$,
+          };
+          page.rootInstance.receiveResource(thing);
+          observedLiterals$.next(observedLiterals);
+          observedRelations$.next(observedRelations);
+          await page.waitForChanges();
+          expect(page.root?.innerHTML).toEqualHtml(`
+        <div>Condition is ${expectedResult}</div>
         `);
-    });
-
-    it('renders templates if a forward link is present (literal)', async () => {
-      const page = await newSpecPage({
-        components: [PosSwitch],
-        html: `
-      <pos-switch>
-        <pos-case if-property="https://schema.org/name">
-          <template>
-            <div>Resource has a name</div>
-          </template>
-        </pos-case>
-      </pos-switch>`,
-      });
-      const observedRelations$ = new Subject<Relation[]>();
-      const observedLiterals$ = new Subject<Literal[]>();
-      const thing = {
-        uri: 'https://pod.example/resource',
-        observeRelations: () => observedRelations$,
-        observeLiterals: () => observedLiterals$,
-      };
-      page.rootInstance.receiveResource(thing);
-      observedRelations$.next([]);
-      observedLiterals$.next([{ predicate: 'https://schema.org/name', label: 'name', values: ['name'] }]);
-      await page.waitForChanges();
-      expect(page.root?.innerHTML).toEqualHtml(`
-        <div>Resource has a name</div>
-        `);
+        },
+      );
     });
 
     it('renders templates if a backward link is present', async () => {
@@ -559,39 +719,6 @@ describe('pos-switch', () => {
       await page.waitForChanges();
       expect(page.root?.innerHTML).toEqualHtml(`
         <div>No conditions match</div>
-        `);
-    });
-
-    it('renders templates when property is absent (not if-property)', async () => {
-      const page = await newSpecPage({
-        components: [PosSwitch],
-        html: `
-      <pos-switch>
-        <pos-case not if-property="https://schema.org/description">
-          <template>
-            <div>Resource has no description</div>
-          </template>
-        </pos-case>
-        <pos-case if-property="https://schema.org/description">
-          <template>
-            <div>Should not render as description is not present</div>
-          </template>
-        </pos-case>
-      </pos-switch>`,
-      });
-      const observedRelations$ = new Subject<Relation[]>();
-      const observedLiterals$ = new Subject<Literal[]>();
-      const thing = {
-        uri: 'https://pod.example/resource',
-        observeRelations: () => observedRelations$,
-        observeLiterals: () => observedLiterals$,
-      };
-      page.rootInstance.receiveResource(thing);
-      observedLiterals$.next([]);
-      observedRelations$.next([]);
-      await page.waitForChanges();
-      expect(page.root?.innerHTML).toEqualHtml(`
-        <div>Resource has no description</div>
         `);
     });
 

--- a/elements/src/components/pos-switch/pos-switch.test.spec.tsx
+++ b/elements/src/components/pos-switch/pos-switch.test.spec.tsx
@@ -5,29 +5,82 @@ import { Subject } from 'rxjs';
 
 describe('pos-switch', () => {
   describe('evaluation of caseElement conditions with test method ', () => {
-    it('renders matching condition with negation', async () => {
-      const page = await newSpecPage({
-        components: [PosSwitch],
-        html: `
-      <pos-switch>
-        <pos-case not if-typeof="http://schema.org/Video"><template><div>Not a Video</div></template></pos-case>
-      </pos-switch>`,
-      });
-      const observedTypes$ = new Subject<RdfType[]>();
-      const thing = {
-        observeTypes: () => observedTypes$,
-      } as unknown as Thing;
-      page.rootInstance.receiveResource(thing);
-      observedTypes$.next([
+    /*
+     Dimensions:
+       - Predicate tested: if-typeof | if-property | if-rev
+       - Condition: present, (some|every)-(eq|lt|lte|gt|gte)
+         - Modifier: negation
+       - Values: relation (URI), string literal, numeric literal
+       - Data state: matched, not matched
+    */
+    describe('if-typeof', () => {
+      // Possible combinations:
+      // Condition: present, not present
+      // Data state: matched, not matched
+      // N.B. Does not take values
+      it.each([
         {
-          label: 'Recipe',
-          uri: 'http://schema.org/Recipe',
+          conditions: 'if-typeof="http://schema.org/Recipe"',
+          observedTypes: [
+            {
+              label: 'Recipe',
+              uri: 'http://schema.org/Recipe',
+            },
+          ],
+          expectedResult: 'matched',
         },
-      ]);
-      await page.waitForChanges();
-      expect(page.root?.innerHTML).toEqualHtml(`
-        <div>Not a Video</div>
+        {
+          conditions: 'not if-typeof="http://schema.org/Recipe"',
+          observedTypes: [],
+          expectedResult: 'matched',
+        },
+        {
+          conditions: 'if-typeof="http://schema.org/Recipe"',
+          observedTypes: [],
+          expectedResult: 'not matched',
+        },
+        {
+          conditions: 'not if-typeof="http://schema.org/Recipe"',
+          observedTypes: [
+            {
+              label: 'Recipe',
+              uri: 'http://schema.org/Recipe',
+            },
+          ],
+          expectedResult: 'not matched',
+        },
+      ])(
+        `renders templates if condition is met: $conditions `,
+        async ({ conditions, observedTypes, expectedResult }) => {
+          const page = await newSpecPage({
+            components: [PosSwitch],
+            html: `
+      <pos-switch>
+        <pos-case ${conditions}>
+          <template>
+            <div>Condition is matched</div>
+          </template>
+        </pos-case>
+        <pos-case else>
+          <template>
+            <div>Condition is not matched</div>
+          </template>
+        </pos-case>
+      </pos-switch>`,
+          });
+          const observedTypes$ = new Subject<RdfType[]>();
+          const thing = {
+            uri: 'https://pod.example/resource',
+            observeTypes: () => observedTypes$,
+          };
+          page.rootInstance.receiveResource(thing);
+          observedTypes$.next(observedTypes);
+          await page.waitForChanges();
+          expect(page.root?.innerHTML).toEqualHtml(`
+        <div>Condition is ${expectedResult}</div>
         `);
+        },
+      );
     });
 
     it('renders templates if a forward link is present (relation)', async () => {

--- a/elements/src/components/pos-switch/pos-switch.test.spec.tsx
+++ b/elements/src/components/pos-switch/pos-switch.test.spec.tsx
@@ -590,6 +590,80 @@ describe('pos-switch', () => {
       );
     });
 
+    describe('evaluating values of property and rev (no relations or literals)', () => {
+      /*
+        40 possible combinations:
+        
+        - Predicates: if-property, if-rev
+        - Condition: (some|every)-(eq|lt|lte|gt|gte)
+        - Modifier: negation
+        - Evaluation state: matched, not matched
+
+        Should always return not matched, or matched with negation
+        For if-property covers both cases where there are no relations or no literals
+        */
+      let testCases = [];
+      for (let direction of ['if-property', 'if-rev']) {
+        for (let semantics of ['some', 'every']) {
+          for (let operator of ['eq', 'gt', 'gte', 'lt', 'lte']) {
+            for (let negation of [true, false]) {
+              const result = negation ? 'matched' : 'not matched';
+              const not = negation ? 'not' : '';
+              testCases.push({
+                direction: direction,
+                conditions: `${direction}="https://schema.org/video" ${not} ${semantics}-value-${operator}="https://resource.test/resource-2"`,
+                expectedResult: result,
+              });
+            }
+          }
+        }
+      }
+
+      expect(testCases.filter(testCase => testCase.expectedResult == 'matched').length).toEqual(20);
+      expect(testCases.filter(testCase => testCase.expectedResult == 'not matched').length).toEqual(20);
+
+      it.each(testCases)(
+        `renders templates if condition is met: $conditions for no relations `,
+        async ({ conditions, expectedResult }) => {
+          const page = await newSpecPage({
+            components: [PosSwitch],
+            html: `
+      <pos-switch>
+        <pos-case ${conditions}>
+          <template>
+            <div>Condition is matched</div>
+          </template>
+        </pos-case>
+        <pos-case else>
+          <template>
+            <div>Condition is not matched</div>
+          </template>
+        </pos-case>
+      </pos-switch>`,
+          });
+          const observedRelations$ = new Subject<Relation[]>();
+          const observedLiterals$ = new Subject<Literal[]>();
+          const observedReverseRelations$ = new Subject<Relation[]>();
+          const thing = {
+            uri: 'https://pod.example/resource',
+            observeRelations: () => observedRelations$,
+            observeLiterals: () => observedLiterals$,
+            observeReverseRelations: () => observedReverseRelations$,
+          };
+          page.rootInstance.receiveResource(thing);
+          observedLiterals$.next([]);
+          observedRelations$.next([]);
+          observedReverseRelations$.next([]);
+          await page.waitForChanges();
+          expect(page.root?.innerHTML).toEqualHtml(`
+        <div>Condition is ${expectedResult}</div>
+        `);
+        },
+      );
+    });
+
+    // TODO evaluating values of property and rev with multiple relations
+
     it('renders templates if forward link value condition is met (literal)', async () => {
       const page = await newSpecPage({
         components: [PosSwitch],

--- a/elements/src/components/pos-switch/pos-switch.test.spec.tsx
+++ b/elements/src/components/pos-switch/pos-switch.test.spec.tsx
@@ -480,39 +480,114 @@ describe('pos-switch', () => {
       );
     });
 
-    it('renders templates if forward link value condition is met (relation)', async () => {
-      const page = await newSpecPage({
-        components: [PosSwitch],
-        html: `
+    describe('evaluating values of property and rev (single relations)', () => {
+      /*
+        80 possible combinations:
+        
+        - Predicates: if-property, if-rev
+        - Condition: (some|every)-(eq|lt|lte|gt|gte)
+        - Modifier: negation
+        - Evaluation state: matched, not matched
+
+        We test three resource values (120 combinations) matching eq, lt, or gt
+        There is no difference between some and every with a single relation.
+        */
+      let testCases = [];
+      for (let direction of ['if-property', 'if-rev']) {
+        for (let semantics of ['some', 'every']) {
+          for (let operator of ['eq', 'gt', 'gte', 'lt', 'lte']) {
+            for (let negation of [true, false]) {
+              for (let resource of [
+                'https://resource.test/resource-1',
+                'https://resource.test/resource-2',
+                'https://resource.test/resource-3',
+              ]) {
+                const cmp = resource.localeCompare('https://resource.test/resource-2');
+                let matches;
+                switch (operator) {
+                  case 'eq':
+                    matches = cmp === 0;
+                    break;
+                  case 'gt':
+                    matches = cmp > 0;
+                    break;
+                  case 'gte':
+                    matches = cmp >= 0;
+                    break;
+                  case 'lt':
+                    matches = cmp < 0;
+                    break;
+                  case 'lte':
+                    matches = cmp <= 0;
+                    break;
+                }
+                matches = negation ? !matches : matches;
+                const result = matches ? 'matched' : 'not matched';
+                const not = negation ? 'not' : '';
+                testCases.push({
+                  direction: direction,
+                  conditions: `${direction}="https://schema.org/video" ${not} ${semantics}-value-${operator}="https://resource.test/resource-2"`,
+                  resource: resource,
+                  expectedResult: result,
+                });
+              }
+            }
+          }
+        }
+      }
+      expect(testCases.filter(testCase => testCase.expectedResult == 'matched').length).toEqual(60);
+      expect(testCases.filter(testCase => testCase.expectedResult == 'not matched').length).toEqual(60);
+
+      it.each(testCases)(
+        `renders templates if condition is met: $conditions for $resource `,
+        async ({ direction, conditions, resource, expectedResult }) => {
+          const page = await newSpecPage({
+            components: [PosSwitch],
+            html: `
       <pos-switch>
-        <pos-case if-property="https://schema.org/video" some-value-eq="https://video.test/video-1">
+        <pos-case ${conditions}>
           <template>
-            <div>Resource has video</div>
+            <div>Condition is matched</div>
           </template>
         </pos-case>
-        <pos-case if-property="https://schema.org/video" some-value-eq="https://video.test/video-missing">
+        <pos-case else>
           <template>
-            <div>Should not render as value condition is not met</div>
+            <div>Condition is not matched</div>
           </template>
         </pos-case>
       </pos-switch>`,
-      });
-      const observedRelations$ = new Subject<Relation[]>();
-      const observedLiterals$ = new Subject<Literal[]>();
-      const thing = {
-        uri: 'https://pod.example/resource',
-        observeRelations: () => observedRelations$,
-        observeLiterals: () => observedLiterals$,
-      };
-      page.rootInstance.receiveResource(thing);
-      observedLiterals$.next([]);
-      observedRelations$.next([
-        { predicate: 'https://schema.org/video', label: 'video', uris: ['https://video.test/video-1'] },
-      ]);
-      await page.waitForChanges();
-      expect(page.root?.innerHTML).toEqualHtml(`
-        <div>Resource has video</div>
+          });
+          const observedRelations$ = new Subject<Relation[]>();
+          const observedLiterals$ = new Subject<Literal[]>();
+          const observedReverseRelations$ = new Subject<Relation[]>();
+          const thing = {
+            uri: 'https://pod.example/resource',
+            observeRelations: () => observedRelations$,
+            observeLiterals: () => observedLiterals$,
+            observeReverseRelations: () => observedReverseRelations$,
+          };
+          const relations = [
+            {
+              predicate: 'https://schema.org/video',
+              label: 'video',
+              uris: [resource],
+            },
+          ];
+          page.rootInstance.receiveResource(thing);
+          observedLiterals$.next([]);
+          if (direction == 'if-property') {
+            observedRelations$.next(relations);
+            observedReverseRelations$.next([]);
+          } else {
+            observedRelations$.next([]);
+            observedReverseRelations$.next(relations);
+          }
+          await page.waitForChanges();
+          expect(page.root?.innerHTML).toEqualHtml(`
+        <div>Condition is ${expectedResult}</div>
         `);
+        },
+      );
     });
 
     it('renders templates if forward link value condition is met (literal)', async () => {
@@ -542,38 +617,6 @@ describe('pos-switch', () => {
       await page.waitForChanges();
       expect(page.root?.innerHTML).toEqualHtml(`
         <div>Resource has name</div>
-        `);
-    });
-
-    it('renders templates if backward link value condition is met', async () => {
-      const page = await newSpecPage({
-        components: [PosSwitch],
-        html: `
-      <pos-switch>
-        <pos-case if-rev="https://schema.org/video" some-value-eq="https://video.test/video-1">
-          <template>
-            <div>Resource is video</div>
-          </template>
-        </pos-case>
-        <pos-case if-rev="https://schema.org/video" some-value-eq="https://video.test/video-missing">
-          <template>
-            <div>Should not render as condition is not met</div>
-          </template>
-        </pos-case>
-      </pos-switch>`,
-      });
-      const observedReverseRelations$ = new Subject<Relation[]>();
-      const thing = {
-        uri: 'https://pod.example/resource',
-        observeReverseRelations: () => observedReverseRelations$,
-      };
-      page.rootInstance.receiveResource(thing);
-      observedReverseRelations$.next([
-        { predicate: 'https://schema.org/video', label: 'video', uris: ['https://video.test/video-1'] },
-      ]);
-      await page.waitForChanges();
-      expect(page.root?.innerHTML).toEqualHtml(`
-        <div>Resource is video</div>
         `);
     });
 

--- a/elements/src/components/pos-switch/pos-switch.test.spec.tsx
+++ b/elements/src/components/pos-switch/pos-switch.test.spec.tsx
@@ -357,36 +357,127 @@ describe('pos-switch', () => {
       );
     });
 
-    it('renders templates if a backward link is present', async () => {
-      const page = await newSpecPage({
-        components: [PosSwitch],
-        html: `
+    describe('if-rev presence/absence', () => {
+      /*
+      12 theoretical combinations:
+
+      - Condition: present, not present
+      - Data state: single value present, no value present, multiple values present
+      - Evaluation state: matched, not matched
+
+      10 possible after removing:
+
+      - Present - no value - matched
+      - Not present - no value - not matched
+      */
+      const VideoLink = {
+        predicate: 'https://schema.org/video',
+        label: 'video',
+        uris: ['https://video.test/resource'],
+      };
+      const RecipeLink = {
+        predicate: 'https://schema.org/recipe',
+        label: 'recipe',
+        uris: ['https://recipe.test/resource'],
+      };
+      const EventLink = {
+        predicate: 'https://schema.org/event',
+        label: 'event',
+        uris: ['https://recipe.test/resource'],
+      };
+      it.each([
+        // Present
+        // Single value
+        {
+          conditions: 'if-rev="https://schema.org/video"',
+          observedReverseRelations: [VideoLink],
+          expectedResult: 'matched',
+        },
+        {
+          conditions: 'if-rev="https://schema.org/video"',
+          observedReverseRelations: [RecipeLink],
+          expectedResult: 'not matched',
+        },
+        // No value
+        // Matched not possible
+        {
+          conditions: 'if-rev="https://schema.org/video"',
+          observedReverseRelations: [],
+          expectedResult: 'not matched',
+        },
+        // Multiple values
+        {
+          conditions: 'if-rev="https://schema.org/video"',
+          observedReverseRelations: [VideoLink, RecipeLink],
+          expectedResult: 'matched',
+        },
+        {
+          conditions: 'if-rev="https://schema.org/video"',
+          observedReverseRelations: [RecipeLink, EventLink],
+          expectedResult: 'not matched',
+        },
+        // Not present
+        // Single value
+        {
+          conditions: 'not if-rev="https://schema.org/video"',
+          observedReverseRelations: [RecipeLink],
+          expectedResult: 'matched',
+        },
+        {
+          conditions: 'not if-rev="https://schema.org/video"',
+          observedReverseRelations: [VideoLink],
+          expectedResult: 'not matched',
+        },
+        // No value
+        // Not matched not possible
+        {
+          conditions: 'not if-rev="https://schema.org/video"',
+          observedReverseRelations: [],
+          expectedResult: 'matched',
+        },
+        // Multiple values
+        {
+          conditions: 'not if-rev="https://schema.org/video"',
+          observedReverseRelations: [EventLink, RecipeLink],
+          expectedResult: 'matched',
+        },
+        {
+          conditions: 'not if-rev="https://schema.org/video"',
+          observedReverseRelations: [VideoLink, EventLink],
+          expectedResult: 'not matched',
+        },
+      ])(
+        `renders templates if condition is met: $conditions `,
+        async ({ conditions, observedReverseRelations, expectedResult }) => {
+          const page = await newSpecPage({
+            components: [PosSwitch],
+            html: `
       <pos-switch>
-        <pos-case if-rev="https://schema.org/video">
+        <pos-case ${conditions}>
           <template>
-            <div>Resource is video</div>
+            <div>Condition is matched</div>
           </template>
         </pos-case>
-        <pos-case if-rev="https://schema.org/subjectOf">
+        <pos-case else>
           <template>
-            <div>Should not render as resource is not object of schema:subjectOf</div>
+            <div>Condition is not matched</div>
           </template>
         </pos-case>
       </pos-switch>`,
-      });
-      const observedReverseRelations$ = new Subject<Relation[]>();
-      const thing = {
-        uri: 'https://pod.example/resource',
-        observeReverseRelations: () => observedReverseRelations$,
-      };
-      page.rootInstance.receiveResource(thing);
-      observedReverseRelations$.next([
-        { predicate: 'https://schema.org/video', label: 'video', uris: ['https://video.test/video-1'] },
-      ]);
-      await page.waitForChanges();
-      expect(page.root?.innerHTML).toEqualHtml(`
-        <div>Resource is video</div>
+          });
+          const observedReverseRelations$ = new Subject<Relation[]>();
+          const thing = {
+            uri: 'https://pod.example/resource',
+            observeReverseRelations: () => observedReverseRelations$,
+          };
+          page.rootInstance.receiveResource(thing);
+          observedReverseRelations$.next(observedReverseRelations);
+          await page.waitForChanges();
+          expect(page.root?.innerHTML).toEqualHtml(`
+        <div>Condition is ${expectedResult}</div>
         `);
+        },
+      );
     });
 
     it('renders templates if forward link value condition is met (relation)', async () => {
@@ -722,36 +813,6 @@ describe('pos-switch', () => {
         `);
     });
 
-    it('renders templates when backward link is absent (not if-rev)', async () => {
-      const page = await newSpecPage({
-        components: [PosSwitch],
-        html: `
-      <pos-switch>
-        <pos-case not if-rev="https://schema.org/video">
-          <template>
-            <div>Resource is not a video object</div>
-          </template>
-        </pos-case>
-        <pos-case if-rev="https://schema.org/video">
-          <template>
-            <div>Should not render as video reverse relation is not present</div>
-          </template>
-        </pos-case>
-      </pos-switch>`,
-      });
-      const observedReverseRelations$ = new Subject<Relation[]>();
-      const thing = {
-        uri: 'https://pod.example/resource',
-        observeReverseRelations: () => observedReverseRelations$,
-      };
-      page.rootInstance.receiveResource(thing);
-      observedReverseRelations$.next([]);
-      await page.waitForChanges();
-      expect(page.root?.innerHTML).toEqualHtml(`
-        <div>Resource is not a video object</div>
-        `);
-    });
-
     it.each([
       // literal + some-value-eq
       {
@@ -760,14 +821,12 @@ describe('pos-switch', () => {
           { predicate: 'https://schema.org/name', label: 'video', values: ['the-name', 'another-name'] },
         ],
         observedRelations: [],
-        observedReverseRelations: [],
         expectedResult: 'matched',
       },
       {
         conditions: 'if-property="https://schema.org/name" some-value-eq="the-name"',
         observedLiterals: [{ predicate: 'https://schema.org/name', label: 'video', values: ['the-name'] }],
         observedRelations: [],
-        observedReverseRelations: [],
         expectedResult: 'matched',
       },
       {
@@ -776,7 +835,6 @@ describe('pos-switch', () => {
           { predicate: 'https://schema.org/name', label: 'video', values: ['the-name', 'another-name'] },
         ],
         observedRelations: [],
-        observedReverseRelations: [],
         expectedResult: 'not matched',
       },
       {
@@ -785,7 +843,6 @@ describe('pos-switch', () => {
           { predicate: 'https://schema.org/name', label: 'video', values: ['the-name', 'another-name'] },
         ],
         observedRelations: [],
-        observedReverseRelations: [],
         expectedResult: 'matched',
       },
       // literal + every-value-eq
@@ -795,14 +852,12 @@ describe('pos-switch', () => {
           { predicate: 'https://schema.org/name', label: 'video', values: ['the-name', 'another-name'] },
         ],
         observedRelations: [],
-        observedReverseRelations: [],
         expectedResult: 'not matched',
       },
       {
         conditions: 'if-property="https://schema.org/name" every-value-eq="the-name"',
         observedLiterals: [{ predicate: 'https://schema.org/name', label: 'video', values: ['the-name'] }],
         observedRelations: [],
-        observedReverseRelations: [],
         expectedResult: 'matched',
       },
       {
@@ -811,7 +866,6 @@ describe('pos-switch', () => {
           { predicate: 'https://schema.org/name', label: 'video', values: ['the-name', 'another-name'] },
         ],
         observedRelations: [],
-        observedReverseRelations: [],
         expectedResult: 'matched',
       },
       // relation + some-value-eq
@@ -825,7 +879,6 @@ describe('pos-switch', () => {
             uris: ['https://video.test/video-1', 'https://video.test/video-2'],
           },
         ],
-        observedReverseRelations: [],
         expectedResult: 'matched',
       },
       {
@@ -838,12 +891,11 @@ describe('pos-switch', () => {
             uris: ['https://video.test/video-1', 'https://video.test/video-2'],
           },
         ],
-        observedReverseRelations: [],
         expectedResult: 'not matched',
       },
     ])(
       `renders templates if condition is met: $conditions `,
-      async ({ conditions, observedLiterals, observedRelations, observedReverseRelations, expectedResult }) => {
+      async ({ conditions, observedLiterals, observedRelations, expectedResult }) => {
         const page = await newSpecPage({
           components: [PosSwitch],
           html: `
@@ -862,17 +914,14 @@ describe('pos-switch', () => {
         });
         const observedRelations$ = new Subject<Relation[]>();
         const observedLiterals$ = new Subject<Literal[]>();
-        const observedReverseRelations$ = new Subject<Relation[]>();
         const thing = {
           uri: 'https://pod.example/resource',
           observeRelations: () => observedRelations$,
           observeLiterals: () => observedLiterals$,
-          observedReverseRelations: () => observedLiterals$,
         };
         page.rootInstance.receiveResource(thing);
         observedLiterals$.next(observedLiterals);
         observedRelations$.next(observedRelations);
-        observedReverseRelations$.next(observedReverseRelations);
         await page.waitForChanges();
         expect(page.root?.innerHTML).toEqualHtml(`
         <div>Condition is ${expectedResult}</div>

--- a/elements/src/components/pos-switch/pos-switch.tsx
+++ b/elements/src/components/pos-switch/pos-switch.tsx
@@ -56,7 +56,11 @@ export class PosSwitch implements ResourceAware {
       state = matchingRelations.length > 0;
     }
     if (caseElement.getAttribute('if-rev') !== null) {
-      state = this.reverseRelations.map(x => x.predicate).includes(caseElement.getAttribute('if-rev'));
+      const matchingRelations = this.reverseRelations.filter(x => x.predicate == caseElement.getAttribute('if-rev'));
+      if (matchingRelations.length > 0) {
+        values = matchingRelations[0].uris;
+      }
+      state = matchingRelations.length > 0;
     }
     if (caseElement.getAttribute('not') != null) {
       state = !state;

--- a/elements/src/components/pos-switch/pos-switch.tsx
+++ b/elements/src/components/pos-switch/pos-switch.tsx
@@ -1,4 +1,4 @@
-import { RdfType, Relation, Thing } from '@pod-os/core';
+import { Literal, RdfType, Relation, Thing } from '@pod-os/core';
 import { Component, Element, Event, h, Host, State } from '@stencil/core';
 import { ResourceAware, ResourceEventEmitter, subscribeResource } from '../events/ResourceAware';
 import { combineLatest, firstValueFrom, Observable, Subject, takeUntil } from 'rxjs';
@@ -20,6 +20,7 @@ export class PosSwitch implements ResourceAware {
   @State() types: RdfType[];
   @State() relations: Relation[];
   @State() reverseRelations: Relation[];
+  @State() literals: Literal[];
 
   private readonly disconnected$ = new Subject<void>();
 
@@ -55,10 +56,15 @@ export class PosSwitch implements ResourceAware {
     }
     if (caseElement.getAttribute('if-property') !== null) {
       const matchingRelations = this.relations.filter(x => x.predicate == caseElement.getAttribute('if-property'));
+      const matchingLiterals = this.literals.filter(x => x.predicate == caseElement.getAttribute('if-property'));
+      values = [];
       if (matchingRelations.length > 0) {
-        values = matchingRelations[0].uris;
+        values.push(...matchingRelations[0].uris);
       }
-      state = matchingRelations.length > 0;
+      if (matchingLiterals.length > 0) {
+        values.push(...matchingLiterals[0].values);
+      }
+      state = matchingRelations.length > 0 || matchingLiterals.length > 0;
     }
     if (caseElement.getAttribute('if-rev') !== null) {
       const matchingRelations = this.reverseRelations.filter(x => x.predicate == caseElement.getAttribute('if-rev'));
@@ -94,6 +100,11 @@ export class PosSwitch implements ResourceAware {
         this.relations = relations;
       });
       observables.push(observeRelations);
+      const observeLiterals = resource.observeLiterals().pipe(takeUntil(this.disconnected$));
+      observeLiterals.subscribe(literals => {
+        this.literals = literals;
+      });
+      observables.push(observeLiterals);
     }
     if (this.caseElements.some(caseElement => caseElement.hasAttribute('if-rev'))) {
       const observeReverseRelations = resource.observeReverseRelations().pipe(takeUntil(this.disconnected$));

--- a/elements/src/components/pos-switch/pos-switch.tsx
+++ b/elements/src/components/pos-switch/pos-switch.tsx
@@ -2,6 +2,7 @@ import { Literal, RdfType, Relation, Thing } from '@pod-os/core';
 import { Component, Element, Event, h, Host, State } from '@stencil/core';
 import { ResourceAware, ResourceEventEmitter, subscribeResource } from '../events/ResourceAware';
 import { combineLatest, firstValueFrom, Observable, Subject, takeUntil } from 'rxjs';
+import { operatorSemanticCombinations, testIfValuesMatchTarget } from './logic';
 
 /**
  * Selects a child template to render based on properties of the subject resource, usually defined by an ancestor `pos-resource` element.
@@ -37,47 +38,19 @@ export class PosSwitch implements ResourceAware {
     }
   }
 
-  test(caseElement): boolean {
-    let state = null;
+  test(caseElement: HTMLPosCaseElement): boolean {
+    let state: boolean | null = null;
     let values = null;
 
-    const compareValue = function (values: string[]): boolean {
+    const compareValues = function (values: string[]): boolean {
       let state = true;
-      for (let semantics of ['some', 'every']) {
-        for (let operator of ['eq', 'gt', 'gte', 'lt', 'lte']) {
-          const attr = `${semantics}-value-${operator}`;
-          if (caseElement.hasAttribute(attr)) {
-            const target = caseElement.getAttribute(attr);
-            const matches = values.map(val => {
-              let cmp;
-              const numVal = Number(val);
-              const numTarget = Number(target);
-              if (!isNaN(numVal) && !isNaN(numTarget)) {
-                cmp = numVal - numTarget;
-              } else {
-                cmp = String(val).localeCompare(String(target));
-              }
-              switch (operator) {
-                case 'eq':
-                  return cmp === 0;
-                case 'gt':
-                  return cmp > 0;
-                case 'gte':
-                  return cmp >= 0;
-                case 'lt':
-                  return cmp < 0;
-                case 'lte':
-                  return cmp <= 0;
-              }
-            });
-            if (semantics == 'some') {
-              state = state && matches.some(val => val);
-            } else if (semantics == 'every') {
-              state = state && matches.every(val => val);
-            }
-          }
+      operatorSemanticCombinations.forEach(({ semantic, operator }) => {
+        const attr = `${semantic}-value-${operator}`;
+        if (caseElement.hasAttribute(attr)) {
+          const targetValue = caseElement.getAttribute(attr)!;
+          state = state && testIfValuesMatchTarget(values, semantic, operator, targetValue);
         }
-      }
+      });
       return state;
     };
 
@@ -104,12 +77,12 @@ export class PosSwitch implements ResourceAware {
       state = matchingRelations.length > 0;
     }
     if (values) {
-      state = state && compareValue(values);
+      state = state && compareValues(values);
     }
     if (caseElement.getAttribute('not') != null) {
       state = !state;
     }
-    return state;
+    return state ?? true;
   }
 
   receiveResource = (resource: Thing) => {
@@ -153,7 +126,7 @@ export class PosSwitch implements ResourceAware {
     if (!this.resource) {
       return null;
     }
-    let state = null;
+    let state: boolean | null = null;
     let activeElements: HTMLPosCaseElement[] = [];
     this.caseElements.forEach(el => {
       const elemState = this.test(el);

--- a/elements/src/components/pos-switch/pos-switch.tsx
+++ b/elements/src/components/pos-switch/pos-switch.tsx
@@ -41,8 +41,13 @@ export class PosSwitch implements ResourceAware {
     let values = null;
 
     const compareValue = function (values: string[]): boolean {
-      if (!caseElement.hasAttribute('some-value-eq')) return true;
-      return values.some(val => val === caseElement.getAttribute('some-value-eq'));
+      if (caseElement.hasAttribute('some-value-eq')) {
+        return values.some(val => val === caseElement.getAttribute('some-value-eq'));
+      }
+      if (caseElement.hasAttribute('every-value-eq')) {
+        return values.every(val => val === caseElement.getAttribute('every-value-eq'));
+      }
+      return true;
     };
 
     if (caseElement.getAttribute('if-typeof') !== null) {

--- a/elements/src/components/pos-switch/pos-switch.tsx
+++ b/elements/src/components/pos-switch/pos-switch.tsx
@@ -42,13 +42,36 @@ export class PosSwitch implements ResourceAware {
     let values = null;
 
     const compareValue = function (values: string[]): boolean {
-      if (caseElement.hasAttribute('some-value-eq')) {
-        return values.some(val => val === caseElement.getAttribute('some-value-eq'));
+      let state = true;
+      for (let semantics of ['some', 'every']) {
+        for (let operator of ['eq', 'gt', 'gte', 'lt', 'lte']) {
+          const attr = `${semantics}-value-${operator}`;
+          if (caseElement.hasAttribute(attr)) {
+            const target = caseElement.getAttribute(attr);
+            const matches = values.map(val => {
+              const cmp = String(val).localeCompare(String(target));
+              switch (operator) {
+                case 'eq':
+                  return cmp === 0;
+                case 'gt':
+                  return cmp > 0;
+                case 'gte':
+                  return cmp >= 0;
+                case 'lt':
+                  return cmp < 0;
+                case 'lte':
+                  return cmp <= 0;
+              }
+            });
+            if (semantics == 'some') {
+              state = state && matches.some(val => val);
+            } else if (semantics == 'every') {
+              state = state && matches.every(val => val);
+            }
+          }
+        }
       }
-      if (caseElement.hasAttribute('every-value-eq')) {
-        return values.every(val => val === caseElement.getAttribute('every-value-eq'));
-      }
-      return true;
+      return state;
     };
 
     if (caseElement.getAttribute('if-typeof') !== null) {

--- a/elements/src/components/pos-switch/pos-switch.tsx
+++ b/elements/src/components/pos-switch/pos-switch.tsx
@@ -49,7 +49,14 @@ export class PosSwitch implements ResourceAware {
           if (caseElement.hasAttribute(attr)) {
             const target = caseElement.getAttribute(attr);
             const matches = values.map(val => {
-              const cmp = String(val).localeCompare(String(target));
+              let cmp;
+              const numVal = Number(val);
+              const numTarget = Number(target);
+              if (!isNaN(numVal) && !isNaN(numTarget)) {
+                cmp = numVal - numTarget;
+              } else {
+                cmp = String(val).localeCompare(String(target));
+              }
               switch (operator) {
                 case 'eq':
                   return cmp === 0;

--- a/elements/src/components/pos-switch/pos-switch.tsx
+++ b/elements/src/components/pos-switch/pos-switch.tsx
@@ -103,11 +103,11 @@ export class PosSwitch implements ResourceAware {
       }
       state = matchingRelations.length > 0;
     }
-    if (caseElement.getAttribute('not') != null) {
-      state = !state;
-    }
     if (values) {
       state = state && compareValue(values);
+    }
+    if (caseElement.getAttribute('not') != null) {
+      state = !state;
     }
     return state;
   }

--- a/elements/src/components/pos-switch/pos-switch.tsx
+++ b/elements/src/components/pos-switch/pos-switch.tsx
@@ -38,17 +38,31 @@ export class PosSwitch implements ResourceAware {
 
   test(caseElement): boolean {
     let state = null;
+    let values = null;
+
+    const compareValue = function (values: string[]): boolean {
+      if (!caseElement.hasAttribute('some-value-eq')) return true;
+      return values.some(val => val === caseElement.getAttribute('some-value-eq'));
+    };
+
     if (caseElement.getAttribute('if-typeof') !== null) {
       state = this.types.map(x => x.uri).includes(caseElement.getAttribute('if-typeof'));
     }
     if (caseElement.getAttribute('if-property') !== null) {
-      state = this.relations.map(x => x.predicate).includes(caseElement.getAttribute('if-property'));
+      const matchingRelations = this.relations.filter(x => x.predicate == caseElement.getAttribute('if-property'));
+      if (matchingRelations.length > 0) {
+        values = matchingRelations[0].uris;
+      }
+      state = matchingRelations.length > 0;
     }
     if (caseElement.getAttribute('if-rev') !== null) {
       state = this.reverseRelations.map(x => x.predicate).includes(caseElement.getAttribute('if-rev'));
     }
     if (caseElement.getAttribute('not') != null) {
       state = !state;
+    }
+    if (values) {
+      state = state && compareValue(values);
     }
     return state;
   }

--- a/storybook/stories/11_pos-switch.stories.mdx
+++ b/storybook/stories/11_pos-switch.stories.mdx
@@ -13,7 +13,11 @@ import {
 
 ## pos-switch
 
-Selects templates to render based on properties of the subject uri
+Selects templates to render based on properties of the subject uri. 
+
+See [pos-case](https://pod-os.org/reference/elements/components/pos-switch/pos-case/) for filter conditions.
+Conditions including testing based on type, if/else logic, presence of forward (`if-property`) and backward (`if-rev`) links, 
+and whether some/every value linked by `if-property` or `if-rev` is equal to/greater than/less than the given attribute.
 
 <Canvas
   withSource="open">
@@ -37,6 +41,21 @@ Selects templates to render based on properties of the subject uri
         <pos-case if-rev="http://xmlns.com/foaf/0.1/primaryTopic">
           <template>
             Primary topic of: <pos-rich-link rev="http://xmlns.com/foaf/0.1/primaryTopic">
+          </template>
+        </pos-case>
+        <pos-case if-rev="http://xmlns.com/foaf/0.1/primaryTopic" some-value-eq="https://pod-os.solidcommunity.net/profile/card">
+          <template>
+            <div>This data is provided by PodOS' profile <pos-rich-link rev="http://xmlns.com/foaf/0.1/primaryTopic">card</pos-rich-link></div>
+          </template>
+        </pos-case>
+        <pos-case if-property="http://www.w3.org/2006/vcard/ns#fn" every-value-gt="Apple">
+          <template>
+            <div><pos-value predicate="http://www.w3.org/2006/vcard/ns#fn"></pos-value> comes after Apple.</div>
+          </template>
+        </pos-case>
+        <pos-case if-property="http://www.w3.org/2006/vcard/ns#fn" every-value-lte="Romeo">
+          <template>
+            <div><pos-value predicate="http://www.w3.org/2006/vcard/ns#fn"></pos-value> comes before or is equal to Romeo.</div>
           </template>
         </pos-case>
       </pos-switch>

--- a/storybook/stories/composition/3_pos-switch-composition.stories.mdx
+++ b/storybook/stories/composition/3_pos-switch-composition.stories.mdx
@@ -36,6 +36,11 @@ import {
                 </pos-list>
               </template>
             </pos-case>
+            <pos-case if-property="http://xmlns.com/foaf/0.1/primaryTopic" every-value-eq="https://pod-os.solidcommunity.net/profile/card#me">
+              <template>
+                <p>This is the profile document for the PodOS project.</p>
+              </template>
+            </pos-case>
             <pos-case if-typeof="http://www.w3.org/ns/iana/media-types/text/turtle#Resource">
               <template>
                 <p>The type of the resource is that defined in the container, updated after loading to also include those defined by the profile document.</p>


### PR DESCRIPTION
Closes #184

- [x] Add some-value-eq and every-value-eq
- [x] Add Thing.observeLiterals
- [x] Support literals for if-property
- [x] Add (some|every)-value-(gt|gte|lt|lte)
- [x] Tests have been written
  - [x] all new code is covered by unit tests
  - [x] the happy path of a new feature is covered by an end-to-end test
    - added to pos-switch integration test
  - [x] manual explorative tests have been performed
- [ ] all dependencies are updated to the latest patch version at minimum
- [x] the [CI pipeline](https://github.com/pod-os/PodOS/actions) passes
- [x] documentation is up-to-date
    - [x] TSDoc style comments on important functions, properties and events
    - [x] stories for new PodOS elements have been added to [storybook](../../storybook)
  - [x] Readme.md files of PodOS elements have been re-generated
  - N/A- architectural decisions are documented as an [ADR](../decisions/0000-use-markdown-architectural-decision-records.md)
  - [x] Changelogs are updated according to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

